### PR TITLE
Updating and fixing dependencies of the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,10 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.204.2</jenkins.version>
     <java.level>8</java.level>
     <concurrency>1</concurrency> <!-- default was 1C but the slave crashs during build with 1C -->
     <maven.javadoc.skip>true</maven.javadoc.skip> <!-- we don't like documentation -->
-
   </properties>
 
   <name>Tuleap Git Branch Source Plugin</name>
@@ -39,6 +38,10 @@
     <developer>
       <id>robinsc</id>
       <name>Clarck Robinson</name>
+    </developer>
+    <developer>
+      <id>goyotm</id>
+      <name> Martin Goyot</name>
     </developer>
   </developers>
   <repositories>
@@ -68,12 +71,6 @@
 
   <!-- depend on other plugins  -->
   <dependencies>
-
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
@@ -107,9 +104,34 @@
       <artifactId>branch-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.21</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.30</version>
     </dependency>
 
     <!-- tests -->


### PR DESCRIPTION
This change is part of [community #14019](https://tuleap.net/plugins/tracker/?aid=14019)

The goal of this commit is to recover a sane state where issuing a `mvn
hpi:run` command would successfully spin up a stable dev environment.

This includes:

  * Removing unnecessary dependency declaration for
    org.jenkins-ci.main.jenkins-core
  * Adding forgotten dependency on the Pipeline:Multibranch plugin
  * Updating targeted Jenkins version as a [vulnerability disclosure has
    been released](https://jenkins.io/security/advisory/2020-01-29/)

⚠️  The [vulnerability warning](https://jenkins.io/security/advisory/2019-11-21/#SECURITY-1658)
is to be ignored as the Script Security Plugin is not one of our
dependencies, but one coming from Pipeline: Multibranch. One can
update the Script Security Plugin on its Jenkins instance, and this
shall be fixed in the next version (2.22) of the Multibranch plugin.
Once out, we'll update our dependency to it. ⚠️