### PR TITLE
Drop specific value for the concurrency property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
   <properties>
     <jenkins.version>2.150.3</jenkins.version>
     <java.level>8</java.level>
-    <concurrency>1</concurrency> <!-- default was 1C but the slave crashs during build with 1C -->
     <maven.javadoc.skip>true</maven.javadoc.skip> <!-- we don't like documentation -->
   </properties>
 


### PR DESCRIPTION
The specific value does not seem to be needed anymore.