### PR TITLE
Introduce the Tuleap webhook.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHook.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import hudson.util.HttpResponses;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.annotation.CheckForNull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class TuleapWebHook implements UnprotectedRootAction {
+
+    private static final Logger LOGGER = Logger.getLogger(TuleapWebHook.class.getName());
+
+    static final String WEBHOOK_URL = "tuleap-hook";
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return "Process request from Tuleap";
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return WEBHOOK_URL;
+    }
+
+    public HttpResponse doIndex(final StaplerRequest request, final StaplerResponse response) {
+        LOGGER.log(Level.INFO, "Tuleap WebHook called with URL: {0} ", request.getRequestURIWithQueryString());
+        return HttpResponses.ok();
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHookCrumbExclusion.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHookCrumbExclusion.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook;
+
+import hudson.Extension;
+import hudson.security.csrf.CrumbExclusion;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Extension
+public class TuleapWebHookCrumbExclusion extends CrumbExclusion {
+
+    @Override
+    public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        final String path = request.getPathInfo();
+        if (path != null && path.equals("/" + TuleapWebHook.WEBHOOK_URL + "/")) {
+            filterChain.doFilter(request, response);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHookCrumbExclusionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHookCrumbExclusionTest.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class TuleapWebHookCrumbExclusionTest {
+
+    @Test
+    public void testItReturnsFalseWhenTheURLIsNotWhiteListed() throws IOException, ServletException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        when(request.getPathInfo()).thenReturn("/amg/");
+        verify(filterChain, never()).doFilter(request, response);
+
+        TuleapWebHookCrumbExclusion crumbExclusion = new TuleapWebHookCrumbExclusion();
+
+        assertFalse(crumbExclusion.process(request, response, filterChain));
+    }
+
+    @Test
+    public void testItReturnsTrueWhenTheURLIsWhiteListed() throws IOException, ServletException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        when(request.getPathInfo()).thenReturn("/tuleap-hook/");
+        verify(filterChain, atMostOnce()).doFilter(request, response);
+
+        TuleapWebHookCrumbExclusion crumbExclusion = new TuleapWebHookCrumbExclusion();
+
+        assertTrue(crumbExclusion.process(request, response, filterChain));
+    }
+}


### PR DESCRIPTION
This is a part of the story #14019 automate jenkins job creation & run
https://tuleap.net/plugins/tracker/?aid=14019

This contribution introduce the new endpoint of the Tuleap webhook.

How to test:
 - Go to the <your_server>/jenkins/tuleap-hook/
=> The page should be blank.
=> The server log added a new entry.