### PR TITLE
Disable codecov comment on PR

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Those comments are a bit massive and annoying since the same information is accessible via the "Checks" added to the PR.