### PR TITLE
Provide a way to add Tuleap Access Key to credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
   <!-- depend on other plugins  -->
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.2-jre</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
     </dependency>
@@ -83,7 +88,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.1</version>
+      <version>2.10.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-guava</artifactId>
+      <version>2.10.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -146,6 +156,13 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
           <version>3.0.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <configuration>
+            <pluginFirstClassLoader>true</pluginFirstClassLoader>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/AccessKeyApi.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/AccessKeyApi.java
@@ -1,0 +1,12 @@
+package org.jenkinsci.plugins.tuleap_api;
+
+import com.google.common.collect.ImmutableList;
+
+public interface AccessKeyApi {
+    String ACCESS_KEY_API = "/access_keys";
+    String SELF_ID = "/self";
+
+    Boolean checkAccessKeyIsValid(String accessKey);
+
+    ImmutableList<AccessKeyScope> getAccessKeyScopes(String accessKey);
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/AccessKeyScope.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/AccessKeyScope.java
@@ -1,0 +1,5 @@
+package org.jenkinsci.plugins.tuleap_api;
+
+public interface AccessKeyScope {
+    String getIdentifier();
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/TuleapApiGuiceModule.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/TuleapApiGuiceModule.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.tuleap_api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import org.jenkinsci.plugins.tuleap_api.internals.TuleapApiClient;
+import org.jenkinsci.plugins.tuleap_api.internals.guice.ObjectMapperProvider;
+import org.jenkinsci.plugins.tuleap_api.internals.guice.OkHttpClientProvider;
+
+public class TuleapApiGuiceModule extends com.google.inject.AbstractModule {
+    @Override
+    protected void configure() {
+        bind(OkHttpClient.class).toProvider(OkHttpClientProvider.class).asEagerSingleton();
+        bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class);
+        bind(AccessKeyApi.class).to(TuleapApiClient.class);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/TuleapAuthorization.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/TuleapAuthorization.java
@@ -1,0 +1,5 @@
+package org.jenkinsci.plugins.tuleap_api;
+
+public interface TuleapAuthorization {
+    String AUTHORIZATION_HEADER = "X-Auth-AccessKey";
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/TuleapApiClient.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/TuleapApiClient.java
@@ -1,0 +1,80 @@
+package org.jenkinsci.plugins.tuleap_api.internals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyApi;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyScope;
+import org.jenkinsci.plugins.tuleap_api.TuleapAuthorization;
+import org.jenkinsci.plugins.tuleap_api.internals.entities.AccessKeyEntity;
+import org.jenkinsci.plugins.tuleap_api.internals.exceptions.InvalidTuleapResponseException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConfiguration;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi {
+    private static final Logger LOGGER = Logger.getLogger(TuleapApiClient.class.getName());
+
+    private OkHttpClient client;
+
+    private TuleapConfiguration tuleapConfiguration;
+
+    private ObjectMapper objectMapper;
+
+    @Inject
+    public TuleapApiClient(
+        TuleapConfiguration tuleapConfiguration,
+        OkHttpClient client,
+        ObjectMapper objectMapper
+    ) {
+        this.tuleapConfiguration = tuleapConfiguration;
+        this.client = client;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Boolean checkAccessKeyIsValid(String accessKey) {
+        Request request = new Request.Builder()
+            .url(tuleapConfiguration.getApiBaseUrl() + this.ACCESS_KEY_API + this.SELF_ID)
+            .header(this.AUTHORIZATION_HEADER, accessKey)
+            .get()
+            .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            return response.code() == 200;
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+
+    @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
+    public ImmutableList<AccessKeyScope> getAccessKeyScopes(String accessKey) {
+        Request request = new Request.Builder()
+            .url(tuleapConfiguration.getApiBaseUrl() + this.ACCESS_KEY_API + this.SELF_ID)
+            .header(this.AUTHORIZATION_HEADER, accessKey)
+            .get()
+            .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (! response.isSuccessful()) {
+                throw new InvalidTuleapResponseException(response);
+            }
+
+            return ImmutableList.copyOf(
+                objectMapper
+                .readValue(Objects.requireNonNull(response.body()).string(), AccessKeyEntity.class)
+                .getScopes()
+            );
+        } catch (IOException | InvalidTuleapResponseException exception) {
+            LOGGER.severe(exception.getMessage());
+            return ImmutableList.of();
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/entities/AccessKeyEntity.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/entities/AccessKeyEntity.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.tuleap_api.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AccessKeyEntity {
+    private ImmutableList<AccessKeyScopeEntity> scopes;
+
+    public AccessKeyEntity(
+        @JsonProperty("scopes") ImmutableList<AccessKeyScopeEntity> scopes
+    ) {
+        this.scopes = scopes;
+    }
+
+    public ImmutableList<AccessKeyScopeEntity> getScopes() {
+        return Optional.ofNullable(scopes).orElse(ImmutableList.of());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/entities/AccessKeyScopeEntity.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/entities/AccessKeyScopeEntity.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.tuleap_api.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyScope;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AccessKeyScopeEntity implements AccessKeyScope {
+    private String identifier;
+
+    public AccessKeyScopeEntity(@JsonProperty("identifier") String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return this.identifier;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/exceptions/InvalidTuleapResponseException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/exceptions/InvalidTuleapResponseException.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.tuleap_api.internals.exceptions;
+
+import okhttp3.Response;
+
+public class InvalidTuleapResponseException extends Exception {
+    private Response response;
+
+    public InvalidTuleapResponseException(Response response) {
+        this.response = response;
+    }
+
+    @Override
+    public String getMessage() {
+        return "The response received from Tuleap is invalid: " + response.toString();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/guice/ObjectMapperProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/guice/ObjectMapperProvider.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.tuleap_api.internals.guice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.inject.Provider;
+import okhttp3.OkHttpClient;
+
+import java.util.concurrent.TimeUnit;
+
+public class ObjectMapperProvider implements Provider<ObjectMapper> {
+
+    @Override
+    public ObjectMapper get() {
+        return new ObjectMapper().registerModule(new GuavaModule());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/guice/OkHttpClientProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_api/internals/guice/OkHttpClientProvider.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.tuleap_api.internals.guice;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import jenkins.model.Jenkins;
+import okhttp3.OkHttpClient;
+import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConfiguration;
+
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+public class OkHttpClientProvider implements Provider<OkHttpClient> {
+    private TuleapConfiguration tuleapConfiguration;
+
+    @Inject
+    public OkHttpClientProvider(TuleapConfiguration tuleapConfiguration) {
+        this.tuleapConfiguration = tuleapConfiguration;
+    }
+
+    @Override
+    public OkHttpClient get() {
+        return new OkHttpClient
+            .Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .cache(null)
+            .proxy(getProxy(getTuleapHost()))
+            .build();
+    }
+
+    private String getTuleapHost() {
+        try {
+            return new URL(tuleapConfiguration.getApiBaseUrl()).getHost();
+        } catch (MalformedURLException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    private Proxy getProxy(String host) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+
+        if (jenkins == null || jenkins.proxy == null) {
+            return Proxy.NO_PROXY;
+        } else {
+            return jenkins.proxy.createProxy(host);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_credentials/AccessKeyChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_credentials/AccessKeyChecker.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.tuleap_credentials;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyApi;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyScope;
+import org.jenkinsci.plugins.tuleap_credentials.exceptions.InvalidAccessKeyException;
+import org.jenkinsci.plugins.tuleap_credentials.exceptions.InvalidScopesForAccessKeyException;
+
+public class AccessKeyChecker {
+    private static ImmutableList<String> MANDATORY_SCOPES = ImmutableList.of("write:rest", "write:git_repository");
+
+    private AccessKeyApi client;
+
+    @Inject
+    public AccessKeyChecker(AccessKeyApi client) {
+        this.client = client;
+    }
+
+    public void verifyAccessKey(String accessKey) throws InvalidAccessKeyException, InvalidScopesForAccessKeyException {
+        if (! accessKeyIsValid(accessKey)) {
+            throw new InvalidAccessKeyException();
+        }
+
+        if (! scopesAreValid(accessKey)) {
+            throw new InvalidScopesForAccessKeyException();
+        }
+    }
+
+    private Boolean accessKeyIsValid(String accessKey) {
+        return client.checkAccessKeyIsValid(accessKey);
+    }
+
+    private Boolean scopesAreValid(String accessKey) {
+        return client
+        .getAccessKeyScopes(accessKey)
+        .stream()
+        .map(AccessKeyScope::getIdentifier)
+        .collect(ImmutableList.toImmutableList())
+        .containsAll(MANDATORY_SCOPES);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessToken.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessToken.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.tuleap_credentials;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.Secret;
+
+public interface TuleapAccessToken extends StandardCredentials {
+
+    /**
+     * @return the token.
+     */
+    @NonNull
+    Secret getToken();
+}
+

--- a/src/main/java/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessTokenImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessTokenImpl.java
@@ -1,0 +1,71 @@
+package org.jenkinsci.plugins.tuleap_credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.tuleap_api.TuleapApiGuiceModule;
+import org.jenkinsci.plugins.tuleap_credentials.exceptions.InvalidAccessKeyException;
+import org.jenkinsci.plugins.tuleap_credentials.exceptions.InvalidScopesForAccessKeyException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+public class TuleapAccessTokenImpl extends BaseStandardCredentials implements TuleapAccessToken {
+
+    @NonNull
+    private final Secret token;
+
+    @DataBoundConstructor
+    public TuleapAccessTokenImpl(
+        @CheckForNull CredentialsScope scope,
+        @CheckForNull String id,
+        @CheckForNull String description,
+        @NonNull String token
+    ) {
+        super(scope, id, description);
+        this.token = Secret.fromString(token);
+    }
+
+    @Override
+    @NonNull
+    public Secret getToken() {
+        return token;
+    }
+
+    @Extension
+    @Symbol("tuleapAccessToken")
+    public static class DescriptorImpl extends CredentialsDescriptor {
+        @Override
+        @NonNull
+        public String getDisplayName() {
+            return Messages.PersonalAccessToken_displayName();
+        }
+
+        @Restricted(NoExternalUse.class)
+        public FormValidation doCheckToken(@QueryParameter String value) {
+            Injector injector = Guice.createInjector(new TuleapApiGuiceModule());
+            Secret secret = Secret.fromString(value);
+            AccessKeyChecker checker = injector.getInstance(AccessKeyChecker.class);
+
+            try {
+                checker.verifyAccessKey(secret.getPlainText());
+                return FormValidation.ok();
+            } catch (InvalidAccessKeyException exception) {
+                return FormValidation
+                    .error(Messages.PersonalAccessToken_invalidAccessKey());
+            } catch (InvalidScopesForAccessKeyException exception) {
+                return FormValidation
+                    .error(Messages.PersonalAccessToken_invalidScopesAccessKey());
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_credentials/exceptions/InvalidAccessKeyException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_credentials/exceptions/InvalidAccessKeyException.java
@@ -1,0 +1,3 @@
+package org.jenkinsci.plugins.tuleap_credentials.exceptions;
+
+public class InvalidAccessKeyException extends Exception {}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_credentials/exceptions/InvalidScopesForAccessKeyException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_credentials/exceptions/InvalidScopesForAccessKeyException.java
@@ -1,0 +1,3 @@
+package org.jenkinsci.plugins.tuleap_credentials.exceptions;
+
+public class InvalidScopesForAccessKeyException extends Exception {}

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_credentials/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_credentials/Messages.properties
@@ -1,0 +1,3 @@
+PersonalAccessToken.invalidAccessKey=The provided Access Key is invalid
+PersonalAccessToken.displayName=Tuleap Access Key
+PersonalAccessToken_invalidScopesAccessKey=The provided Access Key does not have the required scopes

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessTokenImpl/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessTokenImpl/config.jelly
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <f:entry title="${%Token}" field="token">
+        <f:password/>
+    </f:entry>
+    <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/tuleap_api/internals/TuleapApiClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_api/internals/TuleapApiClientTest.java
@@ -1,0 +1,86 @@
+package org.jenkinsci.plugins.tuleap_api.internals;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TuleapApiClientTest {
+    private TuleapConfiguration tuleapConfiguration;
+    private OkHttpClient client;
+    private ObjectMapper mapper;
+    private TuleapApiClient tuleapApiClient;
+
+    @Before
+    public void setUp() {
+        client = mock(OkHttpClient.class);
+        tuleapConfiguration = mock(TuleapConfiguration.class);
+        mapper = new ObjectMapper().registerModule(new GuavaModule());
+        tuleapApiClient = new TuleapApiClient(tuleapConfiguration, client, mapper);
+
+        when(tuleapConfiguration.getApiBaseUrl()).thenReturn("https://example.tuleap.test");
+    }
+
+    @Test
+    public void itShouldReturnFalseIfTuleapServerDoesNotAnswer200() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(400);
+
+        assertFalse(tuleapApiClient.checkAccessKeyIsValid("whatever"));
+    }
+
+    @Test
+    public void itShouldReturnTrueIfTuleapServerAnswers200() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(200);
+
+        assertTrue(tuleapApiClient.checkAccessKeyIsValid("whatever"));
+    }
+
+    @Test
+    public void itShouldReturnAnEmptyScopesListIfCallIsNotSuccessfull() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(false);
+
+        assertEquals(0, tuleapApiClient.getAccessKeyScopes("whatever").size());
+    }
+
+    @Test
+    public void itShouldReturnScopesFromTuleapServerResponse() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+        String json_payload = IOUtils.toString(TuleapApiClientTest.class.getResourceAsStream("access_key_payload.json"));
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.string()).thenReturn(json_payload);
+
+        assertEquals(2, tuleapApiClient.getAccessKeyScopes("whatever").size());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_credentials/AccessKeyCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_credentials/AccessKeyCheckerTest.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.tuleap_credentials;
+
+import com.google.common.collect.ImmutableList;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyApi;
+import org.jenkinsci.plugins.tuleap_api.AccessKeyScope;
+import org.jenkinsci.plugins.tuleap_credentials.exceptions.InvalidAccessKeyException;
+import org.jenkinsci.plugins.tuleap_credentials.exceptions.InvalidScopesForAccessKeyException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AccessKeyCheckerTest {
+    @Mock private AccessKeyApi client;
+    @InjectMocks private AccessKeyChecker accessKeyChecker;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expected = InvalidAccessKeyException.class)
+    public void itShouldThrowAnExceptionIfKeyIsInvalid() throws InvalidScopesForAccessKeyException, InvalidAccessKeyException {
+        final String accessKey = "SomeAccessKey";
+        when(client.checkAccessKeyIsValid(accessKey)).thenReturn(false);
+
+        accessKeyChecker.verifyAccessKey(accessKey);
+    }
+
+    @Test(expected = InvalidScopesForAccessKeyException.class)
+    public void itShouldThrowAnExceptionIfKeyDoesNotHaveTheNeededScopes() throws InvalidScopesForAccessKeyException, InvalidAccessKeyException {
+        final String accessKey = "SomeAccessKey";
+        final AccessKeyScope scope = mock(AccessKeyScope.class);
+
+        when(client.checkAccessKeyIsValid(accessKey)).thenReturn(true);
+        when(scope.getIdentifier()).thenReturn("some:scope");
+        when(client.getAccessKeyScopes(accessKey)).thenReturn(ImmutableList.of(scope));
+
+        accessKeyChecker.verifyAccessKey(accessKey);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessTokenImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_credentials/TuleapAccessTokenImplTest.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.tuleap_credentials;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class TuleapAccessTokenImplTest {
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void configRoundtrip() throws Exception {
+        TuleapAccessTokenImpl expectedToken = new TuleapAccessTokenImpl(
+            CredentialsScope.GLOBAL,
+            "magic-id",
+            "configRoundtrip",
+            "tlp-k1-6.d94b1a79cc0a2f0b9ffb667749eb5567a341fbf08e1c260c2f4b8c5b130bbdb0");
+        CredentialsBuilder builder = new CredentialsBuilder(expectedToken);
+        jenkinsRule.configRoundtrip(builder);
+        jenkinsRule.assertEqualDataBoundBeans(expectedToken, builder.credentials);
+    }
+
+    public static class CredentialsBuilder extends Builder {
+
+        public final Credentials credentials;
+
+        @DataBoundConstructor
+        public CredentialsBuilder(Credentials credentials) {
+            this.credentials = credentials;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+            @Override
+            public String getDisplayName() {
+                return "CredentialsBuilder";
+            }
+
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+
+        }
+
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_api/internals/access_key_payload.json
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_api/internals/access_key_payload.json
@@ -1,0 +1,16 @@
+{
+  "creation_date": "2020-02-17T11:31:05+01:00",
+  "description": "",
+  "expiration_date": null,
+  "id": 5,
+  "last_used_by": "172.18.0.6",
+  "last_used_on": "2020-02-18T18:20:23+01:00",
+  "scopes": [
+    {
+      "identifier": "write:git_repository"
+    },
+    {
+      "identifier": "write:rest"
+    }
+  ]
+}


### PR DESCRIPTION
This change is part of [community #14019](https://tuleap.net/plugins/tracker/?aid=14019)

In order to test this change, on your Jenkins instance, you can go to
credentials management, add a new credential, and select Tuleap access
key. The provided key should be verified, if invalid or if it does not
have all the required scopes ("write:rest", "write:git_repository").