### PR TITLE
Trigger the conerned build when the webhook is called

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/guice/TuleapWebhookGuiceModule.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/guice/TuleapWebhookGuiceModule.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.guice;
+
+import com.google.inject.AbstractModule;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookCheckerImpl;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.JobFinder;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.JobFinderImpl;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.TuleapWebHookProcessor;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.TuleapWebHookProcessorImpl;
+
+public class TuleapWebhookGuiceModule extends AbstractModule {
+    @Override
+    public void configure() {
+        bind(TuleapWebHookChecker.class).to(TuleapWebHookCheckerImpl.class);
+        bind(TuleapWebHookProcessor.class).to(TuleapWebHookProcessorImpl.class);
+        bind(JobFinder.class).to(JobFinderImpl.class);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/guice/TuleapWebhookGuiceModule.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/guice/TuleapWebhookGuiceModule.java
@@ -3,10 +3,7 @@ package org.jenkinsci.plugins.tuleap_git_branch_source.guice;
 import com.google.inject.AbstractModule;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookCheckerImpl;
-import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.JobFinder;
-import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.JobFinderImpl;
-import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.TuleapWebHookProcessor;
-import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.TuleapWebHookProcessorImpl;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.*;
 
 public class TuleapWebhookGuiceModule extends AbstractModule {
     @Override
@@ -14,5 +11,6 @@ public class TuleapWebhookGuiceModule extends AbstractModule {
         bind(TuleapWebHookChecker.class).to(TuleapWebHookCheckerImpl.class);
         bind(TuleapWebHookProcessor.class).to(TuleapWebHookProcessorImpl.class);
         bind(JobFinder.class).to(JobFinderImpl.class);
+        bind(OrganizationFolderRetriever.class).to(OrganizationFolderRetrieverImpl.class);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHook.java
@@ -1,13 +1,17 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source.webhook;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
-import hudson.util.HttpResponses;
+import org.jenkinsci.plugins.tuleap_git_branch_source.guice.TuleapWebhookGuiceModule;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor.TuleapWebHookProcessor;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import javax.annotation.CheckForNull;
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -18,6 +22,13 @@ public class TuleapWebHook implements UnprotectedRootAction {
 
     static final String WEBHOOK_URL = "tuleap-hook";
 
+    private TuleapWebHookProcessor tuleapWebHookActionProcessor;
+
+    public TuleapWebHook() {
+        Injector injector = Guice.createInjector(new TuleapWebhookGuiceModule());
+        this.tuleapWebHookActionProcessor = injector.getInstance(TuleapWebHookProcessor.class);
+    }
+
     @CheckForNull
     @Override
     public String getIconFileName() {
@@ -27,7 +38,7 @@ public class TuleapWebHook implements UnprotectedRootAction {
     @CheckForNull
     @Override
     public String getDisplayName() {
-        return "Process request from Tuleap";
+        return "Process request from Tuleap git repository";
     }
 
     @CheckForNull
@@ -36,9 +47,8 @@ public class TuleapWebHook implements UnprotectedRootAction {
         return WEBHOOK_URL;
     }
 
-    public HttpResponse doIndex(final StaplerRequest request, final StaplerResponse response) {
+    public HttpResponse doIndex(final StaplerRequest request, final StaplerResponse response) throws IOException {
         LOGGER.log(Level.INFO, "Tuleap WebHook called with URL: {0} ", request.getRequestURIWithQueryString());
-        return HttpResponses.ok();
+        return this.tuleapWebHookActionProcessor.process(request);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHook.java
@@ -48,7 +48,7 @@ public class TuleapWebHook implements UnprotectedRootAction {
     }
 
     public HttpResponse doIndex(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        LOGGER.log(Level.INFO, "Tuleap WebHook called with URL: {0} ", request.getRequestURIWithQueryString());
+        LOGGER.log(Level.FINEST, "Tuleap WebHook called with URL: {0} ", request.getRequestURIWithQueryString());
         return this.tuleapWebHookActionProcessor.process(request);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHookCause.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebHookCause.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook;
+
+import hudson.model.Cause;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+public class TuleapWebHookCause extends Cause {
+
+    private WebHookRepresentation representation;
+
+    public TuleapWebHookCause(WebHookRepresentation representation) {
+        this.representation = representation;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return String.format("The job was triggered by '%s' git repository from Tuleap", this.representation.getRepositoryName());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookChecker.java
@@ -1,0 +1,8 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check;
+
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+public interface TuleapWebHookChecker {
+    boolean checkRequestHeaderContentType(String contentType);
+    boolean checkPayloadContent(WebHookRepresentation content);
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerImpl.java
@@ -9,6 +9,6 @@ public class TuleapWebHookCheckerImpl implements TuleapWebHookChecker {
     }
 
     public boolean checkPayloadContent(WebHookRepresentation representation) {
-        return representation.getBranchName() != null && representation.getRepositoryName() != null && representation.getTuleapProjectName() != null;
+        return representation.getBranchName() != null && representation.getRepositoryName() != null && representation.getTuleapProjectId() != null;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerImpl.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check;
+
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+public class TuleapWebHookCheckerImpl implements TuleapWebHookChecker {
+
+    public boolean checkRequestHeaderContentType(String contentType) {
+        return contentType != null && contentType.equals("application/x-www-form-urlencoded");
+    }
+
+    public boolean checkPayloadContent(WebHookRepresentation representation) {
+        return representation.getBranchName() != null && representation.getRepositoryName() != null && representation.getTuleapProjectName() != null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/BranchNotFoundException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/BranchNotFoundException.java
@@ -1,0 +1,4 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions;
+
+public class BranchNotFoundException extends Exception {
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/RepositoryNotFoundException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/RepositoryNotFoundException.java
@@ -1,0 +1,6 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions;
+
+public class RepositoryNotFoundException extends Exception {
+    public RepositoryNotFoundException(){
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/TuleapProjectNotFoundException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/TuleapProjectNotFoundException.java
@@ -1,0 +1,4 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions;
+
+public class TuleapProjectNotFoundException extends Exception {
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/helper/TuleapWebHookHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/helper/TuleapWebHookHelper.java
@@ -1,0 +1,20 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.helper;
+
+import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+import static com.google.common.base.Charsets.UTF_8;
+
+public class TuleapWebHookHelper {
+    public String getStringPayload(StaplerRequest request) throws IOException {
+        return IOUtils.toString(request.getInputStream());
+    }
+
+    public String getUTF8DecodedPayload(String payload) throws UnsupportedEncodingException {
+        return URLDecoder.decode(payload,  UTF_8.name());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/model/WebHookRepresentation.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/model/WebHookRepresentation.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model;
 
 public class WebHookRepresentation {
-    private String tuleapProjectName;
+    private String tuleapProjectId;
     private String repositoryName;
     private String branchName;
 
-    public String getTuleapProjectName() {
-        return tuleapProjectName;
+    public String getTuleapProjectId() {
+        return tuleapProjectId;
     }
 
     public String getRepositoryName() {

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/model/WebHookRepresentation.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/model/WebHookRepresentation.java
@@ -1,0 +1,20 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model;
+
+public class WebHookRepresentation {
+    private String tuleapProjectName;
+    private String repositoryName;
+    private String branchName;
+
+    public String getTuleapProjectName() {
+        return tuleapProjectName;
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    public String getBranchName() {
+        return branchName;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinder.java
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+public interface JobFinder {
+    void triggerConcernedJob(WebHookRepresentation representation) throws BranchNotFoundException, RepositoryNotFoundException, TuleapProjectNotFoundException;
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
@@ -29,7 +29,7 @@ public class JobFinderImpl implements JobFinder {
     }
 
     public void triggerConcernedJob(WebHookRepresentation representation) throws RepositoryNotFoundException, BranchNotFoundException, TuleapProjectNotFoundException {
-        LOGGER.log(Level.INFO, "Retrieve the concerned job...");
+        LOGGER.log(Level.FINEST, "Retrieve the concerned job...");
         Optional<OrganizationFolder> tuleapOrganizationFolder = this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()
             .filter(OrganizationFolder::isSingleOrigin)
             .filter(organizationFolder -> organizationFolder.getSCMNavigators().get(0).getClass().equals(TuleapSCMNavigator.class))
@@ -51,9 +51,9 @@ public class JobFinderImpl implements JobFinder {
 
         if (job.scheduleBuild2(0, new CauseAction(new TuleapWebHookCause(representation)
         )) != null) {
-            LOGGER.log(Level.INFO, "The job has been successfully built");
+            LOGGER.log(Level.FINEST, "The job has been successfully built");
             return;
         }
-        LOGGER.log(Level.INFO, "The build of the job has not been scheduled yet");
+        LOGGER.log(Level.FINEST, "No job was triggered");
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import hudson.model.CauseAction;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import jenkins.branch.MultiBranchProject;
+import jenkins.branch.OrganizationFolder;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMNavigator;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.TuleapWebHookCause;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static jenkins.model.ParameterizedJobMixIn.*;
+
+public class JobFinderImpl implements JobFinder {
+
+    private static final Logger LOGGER = Logger.getLogger(JobFinderImpl.class.getName());
+
+    public void triggerConcernedJob(WebHookRepresentation representation) throws BranchNotFoundException, RepositoryNotFoundException, TuleapProjectNotFoundException {
+        Jenkins.get().getACL();
+
+        try (ACLContext old = ACL.as(ACL.SYSTEM)) {
+
+            LOGGER.log(Level.INFO, "Retrieve the concerned job...");
+
+            for (OrganizationFolder organizationFolder : Jenkins.get().getAllItems(OrganizationFolder.class)) {
+                LOGGER.log(Level.INFO, "Consider the Organization folder: {0}", organizationFolder.getName());
+
+                if (!organizationFolder.isSingleOrigin()) {
+                    LOGGER.log(Level.INFO, "This folder has no project type or has several project types");
+                    continue;
+                }
+
+                if (!organizationFolder.getSCMNavigators().get(0).getClass().equals(TuleapSCMNavigator.class)) {
+                    LOGGER.log(Level.INFO, "This folder is not a Tuleap Project");
+                    continue;
+                }
+
+                if (representation.getTuleapProjectName().equals(organizationFolder.getName())) {
+
+                    MultiBranchProject multiBranchProject = organizationFolder.getJob(representation.getRepositoryName());
+
+                    if (multiBranchProject == null) {
+                        throw new RepositoryNotFoundException();
+                    }
+                    ParameterizedJob job = (ParameterizedJob) multiBranchProject.getItem(representation.getBranchName());
+                    if (job == null) {
+                        throw new BranchNotFoundException();
+                    }
+                    if (job.scheduleBuild2(0, new CauseAction(new TuleapWebHookCause(representation)
+                    )) != null) {
+                        LOGGER.log(Level.INFO, "The job has been successfully built");
+                        return;
+                    }
+                } else {
+                    LOGGER.log(Level.INFO, "This Organization folder does not match");
+                }
+            }
+            LOGGER.log(Level.INFO, "No job found!");
+            throw new TuleapProjectNotFoundException();
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
@@ -33,7 +33,11 @@ public class JobFinderImpl implements JobFinder {
         Optional<OrganizationFolder> tuleapOrganizationFolder = this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()
             .filter(OrganizationFolder::isSingleOrigin)
             .filter(organizationFolder -> organizationFolder.getSCMNavigators().get(0).getClass().equals(TuleapSCMNavigator.class))
-            .filter(organizationFolder -> representation.getTuleapProjectName().equals(organizationFolder.getName()))
+            .filter(organizationFolder -> {
+                TuleapSCMNavigator tuleapSCMNavigator = (TuleapSCMNavigator) organizationFolder.getSCMNavigators().get(0);
+                String projectId = tuleapSCMNavigator.getprojectId();
+                return representation.getTuleapProjectId().equals(projectId);
+            })
             .findFirst();
 
         OrganizationFolder tuleapFolder = tuleapOrganizationFolder.orElseThrow(TuleapProjectNotFoundException::new);

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/OrganizationFolderRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/OrganizationFolderRetriever.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import jenkins.branch.MultiBranchProject;
+import jenkins.branch.OrganizationFolder;
+import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+import java.util.stream.Stream;
+
+public interface OrganizationFolderRetriever {
+    Stream<OrganizationFolder> retrieveTuleapOrganizationFolders() throws TuleapProjectNotFoundException;
+
+    ParameterizedJob retrieveBranchJobFromRepositoryName(MultiBranchProject multiBranchProject, WebHookRepresentation representation);
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/OrganizationFolderRetrieverImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/OrganizationFolderRetrieverImpl.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import jenkins.branch.MultiBranchProject;
+import jenkins.branch.OrganizationFolder;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+import java.util.stream.Stream;
+
+public class OrganizationFolderRetrieverImpl implements OrganizationFolderRetriever {
+    @Override
+    public Stream<OrganizationFolder> retrieveTuleapOrganizationFolders() throws TuleapProjectNotFoundException {
+        return Jenkins.get().getAllItems(OrganizationFolder.class).stream();
+    }
+
+    @Override
+    public ParameterizedJobMixIn.ParameterizedJob retrieveBranchJobFromRepositoryName(MultiBranchProject multiBranchProject, WebHookRepresentation representation){
+        return (ParameterizedJobMixIn.ParameterizedJob) multiBranchProject.getItem(representation.getBranchName());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessor.java
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+
+public interface TuleapWebHookProcessor {
+    HttpResponse process(StaplerRequest request) throws IOException;
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -55,7 +55,7 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
             return HttpResponses.error(500, "Error while decoding the payload");
         }
 
-        LOGGER.log(Level.INFO, "Checking the payload content...");
+        LOGGER.log(Level.FINEST, "Checking the payload content...");
 
         WebHookRepresentation representation = this.gson.fromJson(decodedPayload, WebHookRepresentation.class);
         if (representation == null || !this.webHookChecker.checkPayloadContent(representation)){
@@ -71,7 +71,7 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
             LOGGER.log(Level.SEVERE, e.getMessage());
             return HttpResponses.error(404, "Branch not found");
         } catch (TuleapProjectNotFoundException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, e.getMessage());
             return HttpResponses.error(404, "Tuleap project not found");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
 
 import com.google.gson.Gson;
 import hudson.util.HttpResponses;
-import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
@@ -15,11 +14,8 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.google.common.base.Charsets.UTF_8;
 
 public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
 
@@ -27,7 +23,7 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
 
     private final Gson gson;
 
-    private transient TuleapWebHookChecker webHookChecker;
+    private TuleapWebHookChecker webHookChecker;
 
     private JobFinder jobFinder;
 
@@ -49,21 +45,15 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
         String payload = helper.getStringPayload(request);
 
         if (payload.isEmpty()) {
-            LOGGER.log(Level.WARNING, "Jenkins job cannot be triggered. The request is empty");
             return HttpResponses.error(400, "Jenkins job cannot be triggered. The request is empty");
         }
 
-        LOGGER.log(Level.INFO, "Received the Tuleap commit hook notification : {0}", payload);
-        LOGGER.log(Level.INFO, "Decoding the request...");
         String decodedPayload;
         try {
             decodedPayload = helper.getUTF8DecodedPayload(payload);
         } catch (UnsupportedEncodingException e) {
-            LOGGER.log(Level.WARNING, e.getMessage());
             return HttpResponses.error(500, "Error while decoding the payload");
         }
-
-        LOGGER.log(Level.INFO, "... Done");
 
         LOGGER.log(Level.INFO, "Checking the payload content...");
 
@@ -72,7 +62,6 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
             LOGGER.log(Level.WARNING, "Bad payload format");
             return HttpResponses.error(400, "Bad payload format");
         }
-        LOGGER.log(Level.INFO, "... Done");
         try {
             this.jobFinder.triggerConcernedJob(representation);
         } catch (RepositoryNotFoundException e) {

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -1,0 +1,97 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import com.google.gson.Gson;
+import hudson.util.HttpResponses;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.common.base.Charsets.UTF_8;
+
+public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(TuleapWebHookProcessor.class.getName());
+
+    private final Gson gson;
+
+    private transient TuleapWebHookChecker webHookChecker;
+
+    private JobFinder jobFinder;
+
+    @Inject
+    public TuleapWebHookProcessorImpl(Gson gson, TuleapWebHookChecker webHookChecker, JobFinder jobFinder) {
+        this.gson = gson;
+        this.webHookChecker = webHookChecker;
+        this.jobFinder = jobFinder;
+    }
+
+    public HttpResponse process(StaplerRequest request) throws IOException {
+        if (!this.webHookChecker.checkRequestHeaderContentType(request.getContentType())) {
+            return HttpResponses.error(400, "Content type not supported");
+        }
+
+        String payload = this.getStringPayload(request);
+
+        if (payload.isEmpty()) {
+            LOGGER.log(Level.WARNING, "Jenkins job cannot be triggered. The request is empty");
+            return HttpResponses.error(400, "Jenkins job cannot be triggered. The request is empty");
+        }
+
+        LOGGER.log(Level.INFO, "Received the Tuleap commit hook notification : {0}", payload);
+        LOGGER.log(Level.INFO, "Decoding the request...");
+        String decodedPayload;
+        try {
+            decodedPayload = this.getUTF8DecodedPayload(payload);
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.log(Level.WARNING, e.getMessage());
+            return HttpResponses.error(500, "Error while decoding the payload");
+        }
+
+        LOGGER.log(Level.INFO, "... Done");
+
+        LOGGER.log(Level.INFO, "Checking the payload content...");
+
+        WebHookRepresentation representation = this.gson.fromJson(decodedPayload, WebHookRepresentation.class);
+        if (representation == null || !this.webHookChecker.checkPayloadContent(representation)){
+            LOGGER.log(Level.WARNING, "Bad payload format");
+            return HttpResponses.error(400, "Bad payload format");
+        }
+        LOGGER.log(Level.INFO, "... Done");
+        try {
+            this.jobFinder.triggerConcernedJob(representation);
+        } catch (RepositoryNotFoundException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage());
+            return HttpResponses.error(404, "Repository not found");
+        } catch (BranchNotFoundException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage());
+            return HttpResponses.error(404, "Branch not found");
+        } catch (TuleapProjectNotFoundException e) {
+            e.printStackTrace();
+            return HttpResponses.error(404, "Tuleap project not found");
+        }
+
+        return HttpResponses.ok();
+    }
+
+    // protected for testing purpose
+    protected String getStringPayload(StaplerRequest request) throws IOException {
+        return IOUtils.toString(request.getInputStream());
+    }
+
+    // protected for testing purpose
+    protected String getUTF8DecodedPayload(String payload) throws UnsupportedEncodingException {
+        return URLDecoder.decode(payload,  UTF_8.name());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerTest.java
@@ -30,7 +30,7 @@ public class TuleapWebHookCheckerTest {
     public void testItReturnsTrueIfThePayloadIsCorrect() {
         TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
-        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getTuleapProjectId()).thenReturn("200");
         when(representation.getRepositoryName()).thenReturn("W204");
         when(representation.getBranchName()).thenReturn("C63");
         assertTrue(checker.checkPayloadContent(representation));
@@ -40,7 +40,7 @@ public class TuleapWebHookCheckerTest {
     public void testItReturnsFalseIfThePayloadIsNotCorrect() {
         TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
-        when(representation.getTuleapProjectName()).thenReturn(null);
+        when(representation.getTuleapProjectId()).thenReturn(null);
         when(representation.getRepositoryName()).thenReturn("C63");
         when(representation.getBranchName()).thenReturn(null);
         assertFalse(checker.checkPayloadContent(representation));

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/check/TuleapWebHookCheckerTest.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check;
+
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class TuleapWebHookCheckerTest {
+
+    @Test
+    public void testItReturnsTrueIfTheContentTypeIsCorrect() {
+        TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
+        assertTrue(checker.checkRequestHeaderContentType("application/x-www-form-urlencoded"));
+    }
+
+    @Test
+    public void testItReturnsFalseIfThereIsNoContentType() {
+        TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
+        assertFalse(checker.checkRequestHeaderContentType(null));
+    }
+
+    @Test
+    public void testItReturnsFalseIfTheContentTypeIsIncorrect() {
+        TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
+        assertFalse(checker.checkRequestHeaderContentType("application/zoe"));
+    }
+
+    @Test
+    public void testItReturnsTrueIfThePayloadIsCorrect() {
+        TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getRepositoryName()).thenReturn("W204");
+        when(representation.getBranchName()).thenReturn("C63");
+        assertTrue(checker.checkPayloadContent(representation));
+    }
+
+    @Test
+    public void testItReturnsFalseIfThePayloadIsNotCorrect() {
+        TuleapWebHookChecker checker = new TuleapWebHookCheckerImpl();
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(representation.getTuleapProjectName()).thenReturn(null);
+        when(representation.getRepositoryName()).thenReturn("C63");
+        when(representation.getBranchName()).thenReturn(null);
+        assertFalse(checker.checkPayloadContent(representation));
+    }
+
+
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import jenkins.branch.OrganizationFolder;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import java.io.*;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+
+public class JobFinderTest {
+
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+
+    @Rule
+    public LoggerRule loggerRule = new LoggerRule();
+
+    @Test(expected = TuleapProjectNotFoundException.class)
+    public void testItShouldThrowTuleapProjectNotFoundExceptionWhenTheProjectDoesNotExist() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        jenkins.createProject(OrganizationFolder.class, "Bayerische Motoren Werke");
+        jenkins.createProject(OrganizationFolder.class, "Koenigseggddsfsdgevb");
+        JobFinderImpl finder = new JobFinderImpl();
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        finder.triggerConcernedJob(representation);
+        assertThat(this.loggerRule, LoggerRule.recorded(Level.INFO, containsString("This folder has no project type or has several project types")));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
@@ -33,11 +33,9 @@ public class JobFinderTest {
     @Test(expected = TuleapProjectNotFoundException.class)
     public void testThrowsTuleapProjectNotFoundExceptionWhenThereIsNoTuleapOrganizationFolder() throws TuleapProjectNotFoundException, RepositoryNotFoundException, BranchNotFoundException {
         OrganizationFolder folderWithSeveralOrigin = mock(OrganizationFolder.class);
-        when(folderWithSeveralOrigin.getName()).thenReturn("Bayerische-Motoren-Werke");
         when(folderWithSeveralOrigin.isSingleOrigin()).thenReturn(false);
 
         OrganizationFolder folderWithBadSCMNavigator = mock(OrganizationFolder.class);
-        when(folderWithBadSCMNavigator.getName()).thenReturn("Fabbrica Italiana Automobili Torino");
         when(folderWithBadSCMNavigator.isSingleOrigin()).thenReturn(true);
         List<SCMNavigator> scmNavigatorList = new ArrayList<>();
         SCMNavigator classicNavigator = mock(SCMNavigator.class);
@@ -45,15 +43,15 @@ public class JobFinderTest {
         when(folderWithBadSCMNavigator.getSCMNavigators()).thenReturn(scmNavigatorList);
 
         OrganizationFolder tuleapFolderWithAUnwantedName = mock(OrganizationFolder.class);
-        when(tuleapFolderWithAUnwantedName.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
         when(tuleapFolderWithAUnwantedName.isSingleOrigin()).thenReturn(true);
         List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolderWithAUnwantedName.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+        when(tuleapNavigator.getprojectId()).thenReturn("204");
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
-        when(representation.getTuleapProjectName()).thenReturn("Tata");
+        when(representation.getTuleapProjectId()).thenReturn("8");
 
         JobFinderImpl jobFinder = new JobFinderImpl(this.organizationFolderRetriever);
         jobFinder.triggerConcernedJob(representation);
@@ -62,18 +60,18 @@ public class JobFinderTest {
     @Test(expected = RepositoryNotFoundException.class)
     public void testThrowRepositoryNotFoundExceptionWhenTheRepositoryDoesNotExist() throws TuleapProjectNotFoundException, RepositoryNotFoundException, BranchNotFoundException {
         OrganizationFolder tuleapFolder = mock(OrganizationFolder.class);
-        when(tuleapFolder.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
         when(tuleapFolder.isSingleOrigin()).thenReturn(true);
         List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+        when(tuleapNavigator.getprojectId()).thenReturn("204");
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
         when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
-        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getTuleapProjectId()).thenReturn("204");
 
         MultiBranchProject multiBranchProject = mock(MultiBranchProject.class);
         verify(multiBranchProject, never()).getItem(anyString());
@@ -89,17 +87,17 @@ public class JobFinderTest {
     @Test(expected = BranchNotFoundException.class)
     public void testThrowBranchNotFoundExceptionWhenTheBranchDoesNotExist() throws TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
-        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getTuleapProjectId()).thenReturn("204");
         when(representation.getRepositoryName()).thenReturn("C63");
         when(representation.getBranchName()).thenReturn("W204");
 
         OrganizationFolder tuleapFolder = mock(OrganizationFolder.class);
-        when(tuleapFolder.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
         when(tuleapFolder.isSingleOrigin()).thenReturn(true);
         List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+        when(tuleapNavigator.getprojectId()).thenReturn("204");
 
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
@@ -118,16 +116,16 @@ public class JobFinderTest {
     @Test
     public void testTheBuildIsScheduled() throws TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
-        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getTuleapProjectId()).thenReturn("204");
         when(representation.getRepositoryName()).thenReturn("C63");
 
         OrganizationFolder tuleapFolder = mock(OrganizationFolder.class);
-        when(tuleapFolder.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
         when(tuleapFolder.isSingleOrigin()).thenReturn(true);
         List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+        when(tuleapNavigator.getprojectId()).thenReturn("204");
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
         when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
@@ -1,42 +1,147 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
 
+import hudson.model.CauseAction;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.branch.MultiBranchProject;
 import jenkins.branch.OrganizationFolder;
+import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
+import jenkins.scm.api.SCMNavigator;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMNavigator;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
-import org.junit.ClassRule;
-import org.junit.Rule;
+import org.junit.Before;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
 
-import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
-import static org.hamcrest.Matchers.containsString;
-
-import java.util.logging.Level;
-
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 
 public class JobFinderTest {
 
-    @ClassRule
-    public static JenkinsRule jenkins = new JenkinsRule();
+    private OrganizationFolderRetrieverImpl organizationFolderRetriever;
 
-    @Rule
-    public LoggerRule loggerRule = new LoggerRule();
+    @Before
+    public void setUp() {
+        this.organizationFolderRetriever = mock(OrganizationFolderRetrieverImpl.class);
+    }
 
     @Test(expected = TuleapProjectNotFoundException.class)
-    public void testItShouldThrowTuleapProjectNotFoundExceptionWhenTheProjectDoesNotExist() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
-        jenkins.createProject(OrganizationFolder.class, "Bayerische Motoren Werke");
-        jenkins.createProject(OrganizationFolder.class, "Koenigseggddsfsdgevb");
-        JobFinderImpl finder = new JobFinderImpl();
+    public void testThrowsTuleapProjectNotFoundExceptionWhenThereIsNoTuleapOrganizationFolder() throws TuleapProjectNotFoundException, RepositoryNotFoundException, BranchNotFoundException {
+        OrganizationFolder folderWithSeveralOrigin = mock(OrganizationFolder.class);
+        when(folderWithSeveralOrigin.getName()).thenReturn("Bayerische-Motoren-Werke");
+        when(folderWithSeveralOrigin.isSingleOrigin()).thenReturn(false);
+
+        OrganizationFolder folderWithBadSCMNavigator = mock(OrganizationFolder.class);
+        when(folderWithBadSCMNavigator.getName()).thenReturn("Fabbrica Italiana Automobili Torino");
+        when(folderWithBadSCMNavigator.isSingleOrigin()).thenReturn(true);
+        List<SCMNavigator> scmNavigatorList = new ArrayList<>();
+        SCMNavigator classicNavigator = mock(SCMNavigator.class);
+        scmNavigatorList.add(classicNavigator);
+        when(folderWithBadSCMNavigator.getSCMNavigators()).thenReturn(scmNavigatorList);
+
+        OrganizationFolder tuleapFolderWithAUnwantedName = mock(OrganizationFolder.class);
+        when(tuleapFolderWithAUnwantedName.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(tuleapFolderWithAUnwantedName.isSingleOrigin()).thenReturn(true);
+        List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
+        TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
+        tuleapScmNavigatorList.add(tuleapNavigator);
+        when(tuleapFolderWithAUnwantedName.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(representation.getTuleapProjectName()).thenReturn("Tata");
+
+        JobFinderImpl jobFinder = new JobFinderImpl(this.organizationFolderRetriever);
+        jobFinder.triggerConcernedJob(representation);
+    }
+
+    @Test(expected = RepositoryNotFoundException.class)
+    public void testThrowRepositoryNotFoundExceptionWhenTheRepositoryDoesNotExist() throws TuleapProjectNotFoundException, RepositoryNotFoundException, BranchNotFoundException {
+        OrganizationFolder tuleapFolder = mock(OrganizationFolder.class);
+        when(tuleapFolder.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(tuleapFolder.isSingleOrigin()).thenReturn(true);
+        List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
+        TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
+        tuleapScmNavigatorList.add(tuleapNavigator);
+        when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+
+        Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
+        when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);
+
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
-        finder.triggerConcernedJob(representation);
-        assertThat(this.loggerRule, LoggerRule.recorded(Level.INFO, containsString("This folder has no project type or has several project types")));
+
+        MultiBranchProject multiBranchProject = mock(MultiBranchProject.class);
+        verify(multiBranchProject, never()).getItem(anyString());
+
+        ParameterizedJob job = mock(ParameterizedJob.class);
+        verify(job, never()).scheduleBuild2(anyInt(), any());
+
+        verify(tuleapFolder, never()).getJob(representation.getRepositoryName());
+        JobFinderImpl jobFinder = new JobFinderImpl(this.organizationFolderRetriever);
+        jobFinder.triggerConcernedJob(representation);
+    }
+
+    @Test(expected = BranchNotFoundException.class)
+    public void testThrowBranchNotFoundExceptionWhenTheBranchDoesNotExist() throws TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getRepositoryName()).thenReturn("C63");
+        when(representation.getBranchName()).thenReturn("W204");
+
+        OrganizationFolder tuleapFolder = mock(OrganizationFolder.class);
+        when(tuleapFolder.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(tuleapFolder.isSingleOrigin()).thenReturn(true);
+        List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
+        TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
+        tuleapScmNavigatorList.add(tuleapNavigator);
+        when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+
+
+        Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
+        when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);
+
+        ParameterizedJob job = mock(ParameterizedJob.class);
+        verify(job, never()).scheduleBuild2(anyInt(), any());
+
+        MultiBranchProject multiBranchProject = mock(MultiBranchProject.class);
+        when(tuleapFolder.getJob(representation.getRepositoryName())).thenReturn(multiBranchProject);
+
+        JobFinderImpl jobFinder = new JobFinderImpl(this.organizationFolderRetriever);
+        jobFinder.triggerConcernedJob(representation);
+    }
+
+    @Test
+    public void testTheBuildIsScheduled() throws TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(representation.getTuleapProjectName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(representation.getRepositoryName()).thenReturn("C63");
+
+        OrganizationFolder tuleapFolder = mock(OrganizationFolder.class);
+        when(tuleapFolder.getName()).thenReturn("Aufrecht-Melcher-Großaspach");
+        when(tuleapFolder.isSingleOrigin()).thenReturn(true);
+        List<SCMNavigator> tuleapScmNavigatorList = new ArrayList<>();
+        TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
+        tuleapScmNavigatorList.add(tuleapNavigator);
+        when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
+
+        Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
+        when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);
+
+        MultiBranchProject multiBranchProject = mock(MultiBranchProject.class);
+
+        when(tuleapFolder.getJob(representation.getRepositoryName())).thenReturn(multiBranchProject);
+
+        ParameterizedJob job = mock(ParameterizedJob.class);
+        QueueTaskFuture task = mock(QueueTaskFuture.class);
+        when(this.organizationFolderRetriever.retrieveBranchJobFromRepositoryName(multiBranchProject, representation)).thenReturn(job);
+        when(job.scheduleBuild2(eq(0), any(CauseAction.class))).thenReturn(task);
+
+        JobFinderImpl jobFinder = new JobFinderImpl(this.organizationFolderRetriever);
+        jobFinder.triggerConcernedJob(representation);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
@@ -1,0 +1,200 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
+
+import com.google.gson.Gson;
+import hudson.util.HttpResponses;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+public class TuleapWebHookProcessorTest {
+
+    private Gson gson;
+
+    private TuleapWebHookChecker checker;
+
+    private JobFinder jobFinder;
+
+    @Before
+    public void init() {
+        this.gson = mock(Gson.class);
+        this.checker = mock(TuleapWebHookChecker.class);
+        this.jobFinder = mock(JobFinder.class);
+    }
+
+    @Test
+    public void testItShouldReturn400WhenTheContentTypeIsNotSupported() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn(null);
+        verify(request, never()).getInputStream();
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(false);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder);
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.error(400, "Content type not supported");
+
+        verify(this.gson, never()).fromJson("", WebHookRepresentation.class);
+        verify(this.jobFinder, never()).triggerConcernedJob(any());
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+
+    @Test
+    public void testItShouldReturn400WhenThePayloadIsEmpty() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
+        doReturn("").when(tuleapWebHookProcessor).getStringPayload(request);
+
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.error(400, "Jenkins job cannot be triggered. The request is empty");
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+        verify(this.gson, never()).fromJson(anyString(), any());
+        verify(this.jobFinder, never()).triggerConcernedJob(any());
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+
+    @Test
+    public void testItShouldReturn400WhenBadFormatPayload() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
+        String payload = "{Bad format}";
+        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+
+        WebHookRepresentation representation = new WebHookRepresentation();
+        when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
+        when(this.checker.checkPayloadContent(representation)).thenReturn(false);
+
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.error(400, "Bad payload format");
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+        verify(this.jobFinder, never()).triggerConcernedJob(any());
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+
+    @Test
+    public void testItShouldReturn404WhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
+        String payload = "{Ok format}";
+        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
+        when(this.checker.checkPayloadContent(representation)).thenReturn(true);
+        doThrow(RepositoryNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
+
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.error(404, "Repository not found");
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+
+
+    @Test
+    public void testItShouldReturn404WhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
+        String payload = "{Ok format}";
+        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
+        when(this.checker.checkPayloadContent(representation)).thenReturn(true);
+        doThrow(BranchNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
+
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.error(404, "Branch not found");
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+
+    @Test
+    public void testItShouldReturn404WhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
+        String payload = "{Ok format}";
+        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
+        when(this.checker.checkPayloadContent(representation)).thenReturn(true);
+        doThrow(TuleapProjectNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
+
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.error(404, "Tuleap project not found");
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+
+    @Test
+    public void testItShouldReturn200WhenTheJobIsTriggered() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
+
+        when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
+        String payload = "{Ok format}";
+        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+
+        WebHookRepresentation representation = mock(WebHookRepresentation.class);
+        when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
+        when(this.checker.checkPayloadContent(representation)).thenReturn(true);
+        verify(this.jobFinder, atMostOnce()).triggerConcernedJob(representation);
+
+        HttpResponse expectedResponse;
+        expectedResponse = HttpResponses.ok();
+
+        HttpResponse response = tuleapWebHookProcessor.process(request);
+
+        assertEquals(expectedResponse.toString(), response.toString());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
@@ -2,10 +2,12 @@ package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
 
 import com.google.gson.Gson;
 import hudson.util.HttpResponses;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.TuleapWebHook;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.helper.TuleapWebHookHelper;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,11 +28,14 @@ public class TuleapWebHookProcessorTest {
 
     private JobFinder jobFinder;
 
+    private TuleapWebHookHelper webHookHelper;
+
     @Before
     public void init() {
         this.gson = mock(Gson.class);
         this.checker = mock(TuleapWebHookChecker.class);
         this.jobFinder = mock(JobFinder.class);
+        this.webHookHelper = mock(TuleapWebHookHelper.class);
     }
 
     @Test
@@ -42,7 +47,7 @@ public class TuleapWebHookProcessorTest {
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(false);
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.error(400, "Content type not supported");
 
@@ -61,9 +66,10 @@ public class TuleapWebHookProcessorTest {
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+        when(this.webHookHelper.getStringPayload(request)).thenReturn("");
+        when(this.webHookHelper.getUTF8DecodedPayload(anyString())).thenReturn("");
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
-        doReturn("").when(tuleapWebHookProcessor).getStringPayload(request);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.error(400, "Jenkins job cannot be triggered. The request is empty");
@@ -78,14 +84,16 @@ public class TuleapWebHookProcessorTest {
 
     @Test
     public void testItShouldReturn400WhenBadFormatPayload() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        String payload = "{Bad format}";
+
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+        when(this.webHookHelper.getStringPayload(request)).thenReturn(payload);
+        when(this.webHookHelper.getUTF8DecodedPayload(payload)).thenReturn(payload);
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
-        String payload = "{Bad format}";
-        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
 
         WebHookRepresentation representation = new WebHookRepresentation();
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
@@ -103,14 +111,16 @@ public class TuleapWebHookProcessorTest {
 
     @Test
     public void testItShouldReturn404WhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        String payload = "{Ok format}";
+
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+        when(this.webHookHelper.getStringPayload(request)).thenReturn(payload);
+        when(this.webHookHelper.getUTF8DecodedPayload(payload)).thenReturn(payload);
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
-        String payload = "{Ok format}";
-        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
@@ -128,14 +138,16 @@ public class TuleapWebHookProcessorTest {
 
     @Test
     public void testItShouldReturn404WhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        String payload = "{Ok format}";
+
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+        when(this.webHookHelper.getStringPayload(request)).thenReturn(payload);
+        when(this.webHookHelper.getUTF8DecodedPayload(payload)).thenReturn(payload);
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
-        String payload = "{Ok format}";
-        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
@@ -152,14 +164,16 @@ public class TuleapWebHookProcessorTest {
 
     @Test
     public void testItShouldReturn404WhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        String payload = "{Ok format}";
+
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+        when(this.webHookHelper.getStringPayload(request)).thenReturn(payload);
+        when(this.webHookHelper.getUTF8DecodedPayload(payload)).thenReturn(payload);
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
-        String payload = "{Ok format}";
-        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
@@ -176,14 +190,16 @@ public class TuleapWebHookProcessorTest {
 
     @Test
     public void testItShouldReturn200WhenTheJobIsTriggered() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+        String payload = "{Ok format}";
+
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
         when(this.checker.checkRequestHeaderContentType(request.getContentType())).thenReturn(true);
+        when(this.webHookHelper.getStringPayload(request)).thenReturn(payload);
+        when(this.webHookHelper.getUTF8DecodedPayload(payload)).thenReturn(payload);
 
-        TuleapWebHookProcessorImpl tuleapWebHookProcessor = spy(new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder));
-        String payload = "{Ok format}";
-        doReturn(payload).when(tuleapWebHookProcessor).getStringPayload(request);
+        TuleapWebHookProcessorImpl tuleapWebHookProcessor = new TuleapWebHookProcessorImpl(this.gson, this.checker, this.jobFinder, this.webHookHelper);
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This is a part of story #14019 automate jenkins job creation & run
(https://tuleap.net/plugins/tracker/?aid=14019)

How to test:
 - Create and configure a new Tuleap Project.
 - [OPT] Create and configure another Tuleap Project.
 - [OPT] Create a second Organization Folder project type. (e.g GitHub Organization)
 - [OPT] Create a Freestyle project with the name of the job you want to trigger.
 - curl 'http://yourJenkinsServer.example.test/tuleap-hook/' -H 'Content-Type: application/x-www-form-urlencoded' --data $'{\n "tuleapProjectName": "<tuleap_project_name>",\n "repositoryName":"<tuleap_repository_name>",\n "branchName":"<branch_to_trigger>"\n}' or go to http://yourJenkinsServer.example.test/tuleap-hook/ via the browser and update the request header and the request body, then send the request.
=> The wanted job should be triggered
=> Neither the freestyle job nor the others organization folders should not be triggered or updated
 - Go to the concerned Tuleap Project repository.
=> The Last Success or Last Failure column should be updated if the build is finished.
 - When the build end, go to the console output of the last build.
=> The first line of the console should be : The job was triggered by '<tuleap_repository_name>' git repository from Tuleap.
=> You can see the Jenkins log to see what happened.