### PR TITLE
Check support of JCAsC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,17 @@
 
     <!-- tests -->
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <version>1.3</version>

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/JCAsCTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/JCAsCTest.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.jcasc;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import hudson.security.ACL;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.jenkinsci.plugins.tuleap_credentials.TuleapAccessToken;
+import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConfiguration;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+
+public class JCAsCTest {
+
+    @ClassRule
+    @ConfiguredWithCode("jenkins.yml")
+    public static JenkinsConfiguredWithCodeRule jenkins = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void itShouldImportTheTuleapAccessToken() {
+        final List<TuleapAccessToken> tokens = CredentialsProvider.lookupCredentials(
+            TuleapAccessToken.class,
+            jenkins.jenkins,
+            ACL.SYSTEM,
+            Collections.emptyList()
+        );
+
+        assertThat(tokens, hasSize(1));
+        assertThat(tokens.get(0).getToken().getPlainText(), is("tlp-k1-24.2dd47d2e9280a430f4eb862cfbc85e90e8b286818dcbe85bd60d8feb7162580a"));
+    }
+
+    @Test
+    public void itShouldImportTheTuleapServerConfiguration() {
+        final TuleapConfiguration configuration = TuleapConfiguration.get();
+
+        assertThat(configuration.getDomainUrl(), is("https://my.tuleap.instance.net"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/JCAsCTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/JCAsCTest.java
@@ -12,9 +12,8 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-
 
 public class JCAsCTest {
 
@@ -39,6 +38,6 @@ public class JCAsCTest {
     public void itShouldImportTheTuleapServerConfiguration() {
         final TuleapConfiguration configuration = TuleapConfiguration.get();
 
-        assertThat(configuration.getDomainUrl(), is("https://my.tuleap.instance.net"));
+        assertThat(configuration.getDomainUrl(), is("https://tuleap.example.net"));
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/jenkins.yml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/jenkins.yml
@@ -9,4 +9,4 @@ credentials:
 
 unclassified:
   tuleapConfiguration:
-    domainUrl: https://my.tuleap.instance.net
+    domainUrl: https://tuleap.example.net

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/jenkins.yml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/jcasc/jenkins.yml
@@ -1,0 +1,12 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - tuleapAccessToken:
+              scope: SYSTEM
+              id: "whatever"
+              token: "tlp-k1-24.2dd47d2e9280a430f4eb862cfbc85e90e8b286818dcbe85bd60d8feb7162580a"
+
+unclassified:
+  tuleapConfiguration:
+    domainUrl: https://my.tuleap.instance.net


### PR DESCRIPTION
This change is part of [community #14019](https://tuleap.net/plugins/tracker/?aid=14019)

This commit introduces a test suite that check that our plugin is able
to load its configuration through JCAsC.