### PR TITLE
 Fix the error code returned by the Jenkins server

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,6 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -65,9 +65,8 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
         try {
             this.jobFinder.triggerConcernedJob(representation);
         } catch (RepositoryNotFoundException | BranchNotFoundException | TuleapProjectNotFoundException e) {
-            LOGGER.log(Level.WARNING, e.getMessage());
+            LOGGER.log(Level.WARNING, e.toString());
         }
-
         return HttpResponses.ok();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -65,7 +65,7 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
         try {
             this.jobFinder.triggerConcernedJob(representation);
         } catch (RepositoryNotFoundException | BranchNotFoundException | TuleapProjectNotFoundException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage());
+           e.printStackTrace();
         }
 
         return HttpResponses.ok();

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -64,15 +64,8 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
         }
         try {
             this.jobFinder.triggerConcernedJob(representation);
-        } catch (RepositoryNotFoundException e) {
+        } catch (RepositoryNotFoundException | BranchNotFoundException | TuleapProjectNotFoundException e) {
             LOGGER.log(Level.SEVERE, e.getMessage());
-            return HttpResponses.error(404, "Repository not found");
-        } catch (BranchNotFoundException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage());
-            return HttpResponses.error(404, "Branch not found");
-        } catch (TuleapProjectNotFoundException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage());
-            return HttpResponses.error(404, "Tuleap project not found");
         }
 
         return HttpResponses.ok();

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -65,7 +65,7 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
         try {
             this.jobFinder.triggerConcernedJob(representation);
         } catch (RepositoryNotFoundException | BranchNotFoundException | TuleapProjectNotFoundException e) {
-           e.printStackTrace();
+            LOGGER.log(Level.WARNING, e.getMessage());
         }
 
         return HttpResponses.ok();

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
@@ -17,6 +17,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.logging.Logger;
 
 import static org.mockito.Mockito.*;
 
@@ -110,7 +111,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn200WhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200AndLogWhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -125,7 +126,9 @@ public class TuleapWebHookProcessorTest {
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
         when(this.checker.checkPayloadContent(representation)).thenReturn(true);
-        doThrow(RepositoryNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
+
+        final RepositoryNotFoundException exception = spy(RepositoryNotFoundException.class);
+        doThrow(exception).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.ok();
@@ -133,11 +136,12 @@ public class TuleapWebHookProcessorTest {
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
         assertEquals(expectedResponse.toString(), response.toString());
+        verify(exception, atLeastOnce()).getMessage();
     }
 
 
     @Test
-    public void testItShouldReturn200WhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200AndLogWhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -152,7 +156,9 @@ public class TuleapWebHookProcessorTest {
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
         when(this.checker.checkPayloadContent(representation)).thenReturn(true);
-        doThrow(BranchNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
+
+        final BranchNotFoundException exception = spy(BranchNotFoundException.class);
+        doThrow(exception).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.ok();
@@ -160,10 +166,11 @@ public class TuleapWebHookProcessorTest {
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
         assertEquals(expectedResponse.toString(), response.toString());
+        verify(exception, atLeastOnce()).getMessage();
     }
 
     @Test
-    public void testItShouldReturn200WhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200AndLogWhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -178,7 +185,9 @@ public class TuleapWebHookProcessorTest {
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
         when(this.checker.checkPayloadContent(representation)).thenReturn(true);
-        doThrow(TuleapProjectNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
+
+        final TuleapProjectNotFoundException exception = spy(TuleapProjectNotFoundException.class);
+        doThrow(exception).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.ok();
@@ -186,6 +195,7 @@ public class TuleapWebHookProcessorTest {
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
         assertEquals(expectedResponse.toString(), response.toString());
+        verify(exception, atLeastOnce()).getMessage();
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
@@ -127,8 +127,7 @@ public class TuleapWebHookProcessorTest {
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
         when(this.checker.checkPayloadContent(representation)).thenReturn(true);
 
-        final RepositoryNotFoundException exception = spy(RepositoryNotFoundException.class);
-        doThrow(exception).when(this.jobFinder).triggerConcernedJob(representation);
+        doThrow(RepositoryNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.ok();
@@ -136,7 +135,6 @@ public class TuleapWebHookProcessorTest {
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
         assertEquals(expectedResponse.toString(), response.toString());
-        verify(exception, atLeastOnce()).getMessage();
     }
 
 
@@ -157,16 +155,13 @@ public class TuleapWebHookProcessorTest {
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
         when(this.checker.checkPayloadContent(representation)).thenReturn(true);
 
-        final BranchNotFoundException exception = spy(BranchNotFoundException.class);
-        doThrow(exception).when(this.jobFinder).triggerConcernedJob(representation);
+        doThrow(BranchNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.ok();
-
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
         assertEquals(expectedResponse.toString(), response.toString());
-        verify(exception, atLeastOnce()).getMessage();
     }
 
     @Test
@@ -186,8 +181,7 @@ public class TuleapWebHookProcessorTest {
         when(this.gson.fromJson(payload, WebHookRepresentation.class)).thenReturn(representation);
         when(this.checker.checkPayloadContent(representation)).thenReturn(true);
 
-        final TuleapProjectNotFoundException exception = spy(TuleapProjectNotFoundException.class);
-        doThrow(exception).when(this.jobFinder).triggerConcernedJob(representation);
+        doThrow(TuleapProjectNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
         expectedResponse = HttpResponses.ok();
@@ -195,7 +189,6 @@ public class TuleapWebHookProcessorTest {
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
         assertEquals(expectedResponse.toString(), response.toString());
-        verify(exception, atLeastOnce()).getMessage();
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
@@ -110,7 +110,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn404WhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200WhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -128,7 +128,7 @@ public class TuleapWebHookProcessorTest {
         doThrow(RepositoryNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
-        expectedResponse = HttpResponses.error(404, "Repository not found");
+        expectedResponse = HttpResponses.ok();
 
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
@@ -137,7 +137,7 @@ public class TuleapWebHookProcessorTest {
 
 
     @Test
-    public void testItShouldReturn404WhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200WhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -155,7 +155,7 @@ public class TuleapWebHookProcessorTest {
         doThrow(BranchNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
-        expectedResponse = HttpResponses.error(404, "Branch not found");
+        expectedResponse = HttpResponses.ok();
 
         HttpResponse response = tuleapWebHookProcessor.process(request);
 
@@ -163,7 +163,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn404WhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200WhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -181,7 +181,7 @@ public class TuleapWebHookProcessorTest {
         doThrow(TuleapProjectNotFoundException.class).when(this.jobFinder).triggerConcernedJob(representation);
 
         HttpResponse expectedResponse;
-        expectedResponse = HttpResponses.error(404, "Tuleap project not found");
+        expectedResponse = HttpResponses.ok();
 
         HttpResponse response = tuleapWebHookProcessor.process(request);
 


### PR DESCRIPTION
This change is part of [community #14019](https://tuleap.net/plugins/tracker/?aid=14019)
    
When the job is not found, the server should return 200 and not 404 since the URL path and the request are well formed.
When the job to build is not found, error is still logged.
