### PR TITLE
Use tokenless upload functionality to publish Codecov reports

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,5 +21,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./target/site/jacoco/jacoco.xml


### PR DESCRIPTION
PRs made from forks can successfully publish the code coverage report.

https://github.com/codecov/codecov-action/releases/tag/v1.0.6