### PR TITLE
Version 2.0.0 should be marked as incompatible with previous ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <jenkins.version>2.150.3</jenkins.version>
     <java.level>8</java.level>
     <maven.javadoc.skip>true</maven.javadoc.skip> <!-- we don't like documentation -->
+    <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
   </properties>
 
   <name>Tuleap Git Branch Source Plugin</name>


### PR DESCRIPTION
This makes the incompatibility visible in the the 'Plugin Manager'

https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions