### PR TITLE
Introduce the Tuleap authentication form in the security realm

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm.java
@@ -1,0 +1,56 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.oauth2;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Descriptor;
+import hudson.security.SecurityRealm;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConfiguration;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class TuleapSecurityRealm extends SecurityRealm {
+
+    private String tuleapUri;
+    private String clientId;
+    private Secret clientSecret;
+
+    @DataBoundConstructor
+    public TuleapSecurityRealm(String tuleapUri, String clientId, String clientSecret) {
+        this.tuleapUri = Util.fixEmptyAndTrim(tuleapUri);
+        this.clientId = Util.fixEmptyAndTrim(clientId);
+        this.setClientSecret(Util.fixEmptyAndTrim(clientSecret));
+    }
+
+    public String getTuleapUri() {
+        return tuleapUri;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public Secret getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String secretString) {
+        this.clientSecret = Secret.fromString(secretString);
+    }
+
+    @Override
+    public SecurityComponents createSecurityComponents() {
+        return null;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
+        @Override
+        public String getDisplayName() {
+            return "Tuleap Authentication";
+        }
+
+        public String getDefaultTuleapDomainUrl() {
+            return TuleapConfiguration.get().getDomainUrl();
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm/config.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%TuleapOauthSettings}" >
+        <f:entry title="Tuleap URI"  field="tuleapUri">
+            <f:textbox default="${descriptor.getDefaultTuleapDomainUrl()}" />
+        </f:entry>
+
+        <f:entry title="${%clientId}" field="clientId">
+            <f:textbox />
+        </f:entry>
+
+        <f:entry title="${%clientSecret}" field="clientSecret">
+            <f:password />
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm/config_en.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm/config_en.properties
@@ -1,0 +1,3 @@
+TuleapOauthSettings=Global Tuleap OAuth Settings
+clientSecret= Client Secret
+clientId = Client ID

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/oauth2/TuleapSecurityRealm/config_fr.properties
@@ -1,0 +1,3 @@
+TuleapOauthSettings=Tuleap OAuth Configuration Globale
+clientSecret=Secret Client
+clientId = ID Client


### PR DESCRIPTION
This change is part of [community #14019](https://tuleap.net/plugins/tracker/?aid=14019)

/!\ WARNING /!\: If you have selected "Tuleap Authentication" method, you should not save the configuration if you still want to connect to Jenkins.

How to test:
 - Go to the 'Global Configuration Security' menu
=> You should see the "Tuleap Authentication" button radio in the "Security Realm" part
=> If you click on it you should see the form.