### PR TITLE
Rescan the repository if the branch given in the payload does not have its job

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebhookRetriggerRepositoryScanCause.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/TuleapWebhookRetriggerRepositoryScanCause.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook;
+
+import hudson.model.Cause;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
+
+public class TuleapWebhookRetriggerRepositoryScanCause extends Cause {
+
+    private WebHookRepresentation representation;
+
+    public TuleapWebhookRetriggerRepositoryScanCause(WebHookRepresentation representation) {
+        this.representation = representation;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return String.format("Scan the repository to retrieve the job corresponding to the branch '%s'", this.representation.getBranchName());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/RepositoryScanFailedException.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/exceptions/RepositoryScanFailedException.java
@@ -1,0 +1,4 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions;
+
+public class RepositoryScanFailedException extends Exception {
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinder.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinder.java
@@ -1,10 +1,11 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
 
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryScanFailedException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
 
 public interface JobFinder {
-    void triggerConcernedJob(WebHookRepresentation representation) throws BranchNotFoundException, RepositoryNotFoundException, TuleapProjectNotFoundException;
+    void triggerConcernedJob(WebHookRepresentation representation) throws BranchNotFoundException, RepositoryNotFoundException, TuleapProjectNotFoundException, RepositoryScanFailedException;
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/OrganizationFolderRetrieverImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/OrganizationFolderRetrieverImpl.java
@@ -17,6 +17,6 @@ public class OrganizationFolderRetrieverImpl implements OrganizationFolderRetrie
 
     @Override
     public ParameterizedJobMixIn.ParameterizedJob retrieveBranchJobFromRepositoryName(MultiBranchProject multiBranchProject, WebHookRepresentation representation){
-        return (ParameterizedJobMixIn.ParameterizedJob) multiBranchProject.getItem(representation.getBranchName());
+        return (ParameterizedJobMixIn.ParameterizedJob) multiBranchProject.getItemByBranchName(representation.getBranchName());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorImpl.java
@@ -5,6 +5,7 @@ import hudson.util.HttpResponses;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryScanFailedException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.helper.TuleapWebHookHelper;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
@@ -64,7 +65,7 @@ public class TuleapWebHookProcessorImpl implements TuleapWebHookProcessor {
         }
         try {
             this.jobFinder.triggerConcernedJob(representation);
-        } catch (RepositoryNotFoundException | BranchNotFoundException | TuleapProjectNotFoundException e) {
+        } catch (RepositoryNotFoundException | BranchNotFoundException | TuleapProjectNotFoundException | RepositoryScanFailedException e) {
             LOGGER.log(Level.WARNING, e.toString());
         }
         return HttpResponses.ok();

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/TuleapWebHookProcessorTest.java
@@ -2,10 +2,10 @@ package org.jenkinsci.plugins.tuleap_git_branch_source.webhook.processor;
 
 import com.google.gson.Gson;
 import hudson.util.HttpResponses;
-import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.TuleapWebHook;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.check.TuleapWebHookChecker;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.BranchNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryNotFoundException;
+import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.RepositoryScanFailedException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.exceptions.TuleapProjectNotFoundException;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.helper.TuleapWebHookHelper;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.model.WebHookRepresentation;
@@ -17,7 +17,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import static org.mockito.Mockito.*;
 
@@ -40,7 +39,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn400WhenTheContentTypeIsNotSupported() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn400WhenTheContentTypeIsNotSupported() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
 
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn(null);
@@ -62,7 +61,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn400WhenThePayloadIsEmpty() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn400WhenThePayloadIsEmpty() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
         StaplerRequest request = mock(StaplerRequest.class);
         when(request.getContentType()).thenReturn("application/x-www-form-urlencoded");
 
@@ -84,7 +83,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn400WhenBadFormatPayload() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn400WhenBadFormatPayload() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
         String payload = "{Bad format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -111,7 +110,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn200AndLogWhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200AndLogWhenTheRepositoryIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -139,7 +138,7 @@ public class TuleapWebHookProcessorTest {
 
 
     @Test
-    public void testItShouldReturn200AndLogWhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200AndLogWhenTheBranchIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -165,7 +164,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn200AndLogWhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200AndLogWhenTheTuleapProjectIsNotFound() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);
@@ -192,7 +191,7 @@ public class TuleapWebHookProcessorTest {
     }
 
     @Test
-    public void testItShouldReturn200WhenTheJobIsTriggered() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException {
+    public void testItShouldReturn200WhenTheJobIsTriggered() throws IOException, TuleapProjectNotFoundException, BranchNotFoundException, RepositoryNotFoundException, RepositoryScanFailedException {
         String payload = "{Ok format}";
 
         StaplerRequest request = mock(StaplerRequest.class);


### PR DESCRIPTION
Part of [story #18320](https://tuleap.net/plugins/tracker/?aid=18320)
native support of pull requests in tuleap branch source jenkins plugin

If the job corresponding to the branch name of the payload then a scan
is launched at the repository level. There is only one scan and if the
branch is still not found, then a exception is raised in the log.

How to test :
 - Make sure to bind your git repository from  Tuleap with your Jenkins instance.
 - Push some content in a new branch
=> On the Jenkins side, a new scan of the repository is scheduled
=> After the repository scan, the new job/branch has been added and
built ( at least it is still building ).

If you push in an already existing job/branch in Jenkins, there is no
scan of the repository.
