### PR TITLE
Fix unappropriate error message left behind

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -3,6 +3,7 @@ ProjectMetadataAction.iconDescription=Tuleap project
 SCMNavigator.pronoun=Project
 SCMNavigator.description=Scan a Tuleap project to find all repositories corresponding to criteria
 SCMNavigator.depotSourceCategory=Git repository
+SCMNavigator.aTuleapProjectIsRequiredWarning=A Tuleap Project is required!
 
 BranchSCMHead.pronoun=Branch
 BranchDiscoveryTrait.displayName=Branches autodiscovery

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigator/config.jelly
@@ -5,8 +5,8 @@
         <c:select checkMethod="post"/>
     </f:entry>
 
-    <f:entry title="${%Project}" field="projectId">
-        <f:select/>
+    <f:entry title="${%Project}" field="tuleapProjectId">
+        <f:select checkMethod="post"/>
     </f:entry>
 
     <f:entry title="${%Behaviors}">

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorImplTest.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import hudson.util.FormValidation;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TuleapSCMNavigatorImplTest {
+
+    @Test
+    public void testItReturnsWarningIfThereIsNoProjectIdSet() {
+        TuleapSCMNavigator.DescriptorImpl descriptorImpl = new TuleapSCMNavigator.DescriptorImpl();
+        FormValidation feedbackWithEmptyString = descriptorImpl.doCheckTuleapProjectId("");
+        FormValidation feedbackWithNull = descriptorImpl.doCheckTuleapProjectId(null);
+
+        assertEquals(
+            Messages.SCMNavigator_aTuleapProjectIsRequiredWarning(),
+            feedbackWithEmptyString.getMessage()
+        );
+
+        assertEquals(
+            FormValidation.Kind.ERROR,
+            feedbackWithEmptyString.kind
+        );
+
+        assertEquals(
+            Messages.SCMNavigator_aTuleapProjectIsRequiredWarning(),
+            feedbackWithNull.getMessage()
+        );
+
+        assertEquals(
+            FormValidation.Kind.ERROR,
+            feedbackWithNull.kind
+        );
+    }
+
+    @Test
+    public void testItReturnsNothingIfTheProjectIdfIsSet(){
+        TuleapSCMNavigator.DescriptorImpl descriptorImpl = new TuleapSCMNavigator.DescriptorImpl();
+
+        assertEquals(
+            FormValidation.ok(),
+            descriptorImpl.doCheckTuleapProjectId("1")
+        );
+    }
+}


### PR DESCRIPTION
The error message used to be there to prevent a faulty configuration of
the include/exclude which had not sane defaults. Now that the defaults
are sane again, we can remove it and introduce a proper project check on
the project selection box.
