### PR TITLE
Add a branch discovery trait to TuleapSCMSource

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.tuleap_git_branch_source;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Action;
@@ -27,6 +26,7 @@ import jenkins.scm.api.*;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapBranchDiscoveryTrait;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -116,9 +116,7 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
     @Override
     protected void retrieve(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer,
         @CheckForNull SCMHeadEvent<?> event, @NonNull TaskListener listener) throws IOException, InterruptedException {
-        try (final TuleapSCMSourceRequest request = new TuleapSCMSourceContext(criteria, observer)
-                .withTraits(traits).wantBranches(true)
-                .newRequest(this, listener)) {
+        try (final TuleapSCMSourceRequest request = new TuleapSCMSourceContext(criteria, observer).withTraits(traits).newRequest(this, listener)) {
             TuleapAccessToken credentials = lookupScanCredentials((Item) getOwner(), getApiBaseUri(),
                 getCredentialsId());
             setCredentials(credentials);
@@ -130,7 +128,6 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
                     .withCommand(new TuleapClientRawCmd.Branches(this.repository.getId()))
                     .configure()
                     .call();
-                request.setBranchesFromTuleapApi(branches);
                 int count = 0;
                 for (TuleapBranches branch : branches.collect(Collectors.toList())) {
                     count++;
@@ -292,7 +289,7 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
         }
 
         public List<SCMSourceTrait> getTraitsDefaults() {
-            return Arrays.asList(new RefSpecsSCMSourceTrait());
+            return Arrays.asList(new TuleapBranchDiscoveryTrait(), new RefSpecsSCMSourceTrait());
         }
 
         @RequirePOST

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
@@ -27,8 +27,6 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
 
     /**
      * Returns {@code true} if the {@link TuleapSCMSourceRequest} will need information about branches.
-     *
-     * @return {@code true} if the {@link TuleapSCMSourceRequest} will need information about branches.
      */
     public final boolean wantBranches() {
         return wantBranches;

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
@@ -3,16 +3,8 @@ package org.jenkinsci.plugins.tuleap_git_branch_source;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.TaskListener;
-import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapBranches;
-import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapGitBranch;
-import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceRequest;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Stream;
 
 public class TuleapSCMSourceRequest extends SCMSourceRequest {
 
@@ -21,56 +13,13 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
      */
     private final boolean fetchBranches;
 
-    /**
-     * The set of origin branch names that the request is scoped to or {@code null} if the request is not limited.
-     */
-    @CheckForNull
-    private final Set<String> requestBranchNames;
-
-    /**
-     * The branch details or {@code null} if not {@link #isFetchBranches()}.
-     */
-    @CheckForNull
-    private Stream<TuleapGitBranch> branches;
-
-    private Stream<TuleapBranches> branchesFromTuleapApi;
-
     protected TuleapSCMSourceRequest(@NonNull SCMSource source, @NonNull TuleapSCMSourceContext context,
                                      @CheckForNull TaskListener listener) {
         super(source, context, listener);
 
         fetchBranches = context.wantBranches();
-        Set<SCMHead> includes = context.observer().getIncludes();
-        if (includes != null) {
-            Set<String> branchNames = new HashSet<>(includes.size());
-            for (SCMHead head : includes) {
-                if (head instanceof TuleapBranchSCMHead) {
-                    branchNames.add(head.getName());
-                }
-            }
-
-            this.requestBranchNames = Collections.unmodifiableSet(branchNames);
-        } else {
-            this.requestBranchNames = new HashSet<>();
-        }
     }
     public boolean isFetchBranches() {
         return fetchBranches;
-    }
-
-    public Stream<TuleapGitBranch> getBranches() {
-        return branches;
-    }
-
-    public void setBranches(Stream<TuleapGitBranch> branches) {
-        this.branches = branches;
-    }
-
-    public Stream<TuleapBranches> getBranchesFromTuleapApi() {
-        return branchesFromTuleapApi;
-    }
-
-    public void setBranchesFromTuleapApi(Stream<TuleapBranches> branches){
-        this.branchesFromTuleapApi = branches;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapBranchDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapBranchDiscoveryTrait.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.trait;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.tuleap_git_branch_source.Messages;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceContext;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class TuleapBranchDiscoveryTrait extends SCMSourceTrait {
+
+    @DataBoundConstructor
+    public TuleapBranchDiscoveryTrait() {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        TuleapSCMSourceContext tuleapSourceContext = (TuleapSCMSourceContext) context;
+        tuleapSourceContext.wantBranches(true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category.isUncategorized();
+    }
+
+    @Symbol("tuleapBranchDiscovery")
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.TuleapBranchDiscoveryTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return TuleapSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return TuleapSCMSource.class;
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -5,6 +5,7 @@ SCMNavigator.description=Scan a Tuleap project to find all repositories correspo
 SCMNavigator.depotSourceCategory=Git repository
 
 BranchSCMHead.pronoun=Branch
-BranchDiscoveryTrait.displayName=Branches autodiscovery
+
+TuleapBranchDiscoveryTrait.displayName=Tuleap branches autodiscovery
 
 WildcardSCMSourceFilterTrait.displayName=Filter repositories by name (wildcards)

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config.jelly
@@ -1,6 +1,0 @@
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%Strategy}" field="strategy">
-        <f:select default="1"/>
-    </f:entry>
-</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_en-US.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_en-US.properties
@@ -1,1 +1,0 @@
-Strategy=Strategy

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_en.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_en.properties
@@ -1,1 +1,0 @@
-Strategy=Strategy

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_fr-FR.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_fr-FR.properties
@@ -1,1 +1,0 @@
-Strategy=Strat\u00E9gie

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/config_fr.properties
@@ -1,1 +1,0 @@
-Strategy=Strat\u00E9gie

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/trait/UserForkRepositoryTrait/help.html
@@ -1,3 +1,0 @@
-<div>
-    Exclude user's personal forks from watched repositories (**/u/*.git).
-</div>

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDefaultConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDefaultConfigurationTest.java
@@ -6,6 +6,7 @@ import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait;
 import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapBranchDiscoveryTrait;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -36,7 +37,8 @@ public class TuleapSCMNavigatorDefaultConfigurationTest {
                     instanceOf(WildcardSCMSourceFilterTrait.class),
                     hasProperty("includes", is("*")),
                     hasProperty("excludes", is(""))),
-                Matchers.instanceOf(RefSpecsSCMSourceTrait.class)
+                Matchers.instanceOf(RefSpecsSCMSourceTrait.class),
+                Matchers.instanceOf(TuleapBranchDiscoveryTrait.class)
             )
         );
     }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContextTest.java
@@ -2,15 +2,13 @@ package org.jenkinsci.plugins.tuleap_git_branch_source;
 
 import jenkins.scm.api.SCMHeadObserver;
 import org.junit.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
 
 public class TuleapSCMSourceContextTest {
 
     @Test
     public void testDefaultContext() {
         TuleapSCMSourceContext tuleapSourceContext = new TuleapSCMSourceContext(null, SCMHeadObserver.none());
-        assertThat(tuleapSourceContext.wantBranches(), is(false));
+        assertFalse(tuleapSourceContext.wantBranches());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContextTest.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import jenkins.scm.api.SCMHeadObserver;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class TuleapSCMSourceContextTest {
+
+    @Test
+    public void testDefaultContext() {
+        TuleapSCMSourceContext tuleapSourceContext = new TuleapSCMSourceContext(null, SCMHeadObserver.none());
+        assertThat(tuleapSourceContext.wantBranches(), is(false));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapBranchDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapBranchDiscoveryTraitTest.java
@@ -5,9 +5,7 @@ import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceContext;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class TuleapBranchDiscoveryTraitTest {
 
@@ -21,6 +19,6 @@ public class TuleapBranchDiscoveryTraitTest {
 
         tuleapSourceContext.withTrait(branchDiscoveryTrait);
 
-        assertThat(tuleapSourceContext.wantBranches(), is(true));
+        assertTrue(tuleapSourceContext.wantBranches());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapBranchDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapBranchDiscoveryTraitTest.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.trait;
+
+import jenkins.scm.api.SCMHeadObserver;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceContext;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TuleapBranchDiscoveryTraitTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testContextWantsBranchesIfTraitIsLoaded() {
+        TuleapSCMSourceContext tuleapSourceContext = new TuleapSCMSourceContext(null, SCMHeadObserver.none());
+        TuleapBranchDiscoveryTrait branchDiscoveryTrait = new TuleapBranchDiscoveryTrait();
+
+        tuleapSourceContext.withTrait(branchDiscoveryTrait);
+
+        assertThat(tuleapSourceContext.wantBranches(), is(true));
+    }
+}


### PR DESCRIPTION
This is part of [story #18320](https://tuleap.net/plugins/tracker/?aid=18320)

In the job configuration view of a Tuleap Project, you should have a
Branch discovery trait.

This trait should be present for any new job configuration by default.

Having this trait means that we will look for branches. If you remove
it, we don't anymore.