### PR TITLE
Choosen Tuleap project is not saved after Tuleap job configuration saving

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderImpl.java
@@ -5,7 +5,6 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jenkins.branch.MultiBranchProject;
 import jenkins.branch.OrganizationFolder;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMNavigator;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.TuleapWebHookCause;
 import org.jenkinsci.plugins.tuleap_git_branch_source.webhook.TuleapWebhookRetriggerRepositoryScanCause;
@@ -42,7 +41,7 @@ public class JobFinderImpl implements JobFinder {
                 .filter(organizationFolder -> organizationFolder.getSCMNavigators().get(0).getClass().equals(TuleapSCMNavigator.class))
                 .filter(organizationFolder -> {
                     TuleapSCMNavigator tuleapSCMNavigator = (TuleapSCMNavigator) organizationFolder.getSCMNavigators().get(0);
-                    String projectId = tuleapSCMNavigator.getprojectId();
+                    String projectId = tuleapSCMNavigator.getTuleapProjectId();
                     return representation.getTuleapProjectId().equals(projectId);
                 })
                 .findFirst();

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorConfigurationLoadingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorConfigurationLoadingTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source;
 
-import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.trait.RegexSCMSourceFilterTrait;
 import jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait;
@@ -21,7 +20,7 @@ public class TuleapSCMNavigatorConfigurationLoadingTest extends TuleapBranchSour
     public void new_project_by_default(){
 
         assertThat(instance.id(), is("https://www.tuleap.example.test::3280"));
-        assertThat(instance.getprojectId(), is("3280"));
+        assertThat(instance.getTuleapProjectId(), is("3280"));
         assertThat(instance.getCredentialsId(), is("fe09fd0e-7287-44a1-b0b5-746accd227c1"));
         assertThat(instance.getApiUri(), is("https://www.tuleap.example.test/api"));
         assertThat(instance.getGitBaseUri(), is("https://www.tuleap.example.test/plugins/git/"));

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/webhook/processor/JobFinderTest.java
@@ -50,7 +50,7 @@ public class JobFinderTest {
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolderWithAUnwantedName.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
-        when(tuleapNavigator.getprojectId()).thenReturn("204");
+        when(tuleapNavigator.getTuleapProjectId()).thenReturn("204");
 
         WebHookRepresentation representation = mock(WebHookRepresentation.class);
         when(representation.getTuleapProjectId()).thenReturn("8");
@@ -67,7 +67,7 @@ public class JobFinderTest {
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
-        when(tuleapNavigator.getprojectId()).thenReturn("204");
+        when(tuleapNavigator.getTuleapProjectId()).thenReturn("204");
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
         when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);
@@ -99,7 +99,7 @@ public class JobFinderTest {
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
-        when(tuleapNavigator.getprojectId()).thenReturn("204");
+        when(tuleapNavigator.getTuleapProjectId()).thenReturn("204");
 
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
@@ -129,7 +129,7 @@ public class JobFinderTest {
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
-        when(tuleapNavigator.getprojectId()).thenReturn("204");
+        when(tuleapNavigator.getTuleapProjectId()).thenReturn("204");
 
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
@@ -157,7 +157,7 @@ public class JobFinderTest {
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
-        when(tuleapNavigator.getprojectId()).thenReturn("204");
+        when(tuleapNavigator.getTuleapProjectId()).thenReturn("204");
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
         when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);
@@ -187,7 +187,7 @@ public class JobFinderTest {
         TuleapSCMNavigator tuleapNavigator = mock(TuleapSCMNavigator.class);
         tuleapScmNavigatorList.add(tuleapNavigator);
         when(tuleapFolder.getSCMNavigators()).thenReturn(tuleapScmNavigatorList);
-        when(tuleapNavigator.getprojectId()).thenReturn("204");
+        when(tuleapNavigator.getTuleapProjectId()).thenReturn("204");
 
         Stream<OrganizationFolder> stream = Stream.<OrganizationFolder>builder().add(tuleapFolder).build();
         when(this.organizationFolderRetriever.retrieveTuleapOrganizationFolders()).thenReturn(stream);

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorConfigurationLoadingTest/new_project_by_default.xml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorConfigurationLoadingTest/new_project_by_default.xml
@@ -1,5 +1,5 @@
 <org.jenkinsci.plugins.tuleap__git__branch__source.TuleapSCMNavigator>
-	<projectId>3280</projectId>
+	<tuleapProjectId>3280</tuleapProjectId>
 	<traits>
 		<jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait>
 			<includes>*</includes>


### PR DESCRIPTION

Part of [story #18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

Introduced by 83bf19e8de2d3c8f1abb5a321793a1b4a442cfe6

Applying this patch should allow the user to save the project they want
to scan during the Tuleap Job configuration