### PR TITLE
Build and archive plugin artifact to ease the tests

### DIFF
--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -1,0 +1,27 @@
+name: Archive plugin artifact
+
+permissions: read-all
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build and archive
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+      - name: Build
+        run: mvn -Dmaven.test.skip=true -Dspotbugs.skip=true --batch-mode --show-version clean install 
+      - name: Archive
+        uses: actions/upload-artifact@v2.2.3
+        with:
+          path: target/tuleap-git-branch-source.hpi


### PR DESCRIPTION
The default retention days have been kept (90 days), we can customize it if we see the need.