### PR TITLE
User should choose if they want to notify Tuleap.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
@@ -15,6 +15,8 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
      */
     private boolean wantBranches = false;
 
+    private boolean notifyPullRequest = false;
+
     public TuleapSCMSourceContext(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
     }
@@ -32,6 +34,10 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
         return wantBranches;
     }
 
+    public final boolean isNotifyPullRequest() {
+        return this.notifyPullRequest;
+    }
+
     /**
      * Adds a requirement for branch details to any {@link TuleapSCMSourceContext} for this context.
      *
@@ -43,6 +49,12 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
     @NonNull
     public TuleapSCMSourceContext wantBranches(boolean include) {
         wantBranches = wantBranches || include;
+        return this;
+    }
+
+    @NonNull
+    public TuleapSCMSourceContext notifyPullRequest(boolean notify) {
+        this.notifyPullRequest = this.notifyPullRequest || notify;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
@@ -13,13 +13,20 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
      */
     private final boolean fetchBranches;
 
+    private final boolean notifyPullRequest;
+
     protected TuleapSCMSourceRequest(@NonNull SCMSource source, @NonNull TuleapSCMSourceContext context,
                                      @CheckForNull TaskListener listener) {
         super(source, context, listener);
 
-        fetchBranches = context.wantBranches();
+        this.fetchBranches = context.wantBranches();
+        this.notifyPullRequest = context.isNotifyPullRequest();
     }
     public boolean isFetchBranches() {
-        return fetchBranches;
+        return this.fetchBranches;
+    }
+
+    public boolean isNotifyPullRequest() {
+        return this.notifyPullRequest;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusHandler.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.notify;
+
+import hudson.model.Run;
+import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapCommitNotificationTrait;
+
+import java.io.PrintStream;
+
+public class TuleapPipelineStatusHandler {
+
+    private final TuleapPipelineStatusNotifier notifier;
+
+    public TuleapPipelineStatusHandler(TuleapPipelineStatusNotifier notifier) {
+        this.notifier = notifier;
+    }
+
+    public void handleCommitNotification(Run<?, ?> build, PrintStream logger, TuleapBuildStatus status) {
+        TuleapSCMSource source = this.getTuleapSCMSource(build);
+
+        if (source == null) {
+            return;
+        }
+
+        if (!this.isCommitNotificationTraitsEnabled(source)) {
+            return;
+        }
+
+        logger.println("Sending the commit build status");
+        this.notifier.sendBuildStatusToTuleap(build, logger, status, source);
+    }
+
+    private TuleapSCMSource getTuleapSCMSource(Run<?, ?> build) {
+        final SCMSource source = SCMSource.SourceByItem.findSource(build.getParent());
+        if (!(source instanceof TuleapSCMSource)) {
+            return null;
+        }
+        return (TuleapSCMSource) source;
+    }
+
+    private boolean isCommitNotificationTraitsEnabled(TuleapSCMSource source) {
+        return source.getTraits().stream().anyMatch(scmSourceTrait ->
+            scmSourceTrait instanceof TuleapCommitNotificationTrait);
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifier.java
@@ -1,4 +1,4 @@
-package org.jenkinsci.plugins.tuleap_git_branch_source;
+package org.jenkinsci.plugins.tuleap_git_branch_source.notify;
 
 import hudson.model.Run;
 import hudson.plugins.git.util.BuildData;
@@ -6,7 +6,7 @@ import io.jenkins.plugins.tuleap_api.client.GitApi;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 
-import jenkins.scm.api.SCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
 import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConnector;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,22 +19,7 @@ public class TuleapPipelineStatusNotifier {
         this.gitApi = gitApi;
     }
 
-    @Nullable
-    private TuleapSCMSource getTuleapSCMSource(Run<?, ?> build) {
-        final SCMSource source = SCMSource.SourceByItem.findSource(build.getParent());
-        if (!(source instanceof TuleapSCMSource)) {
-            return null;
-        }
-        return (TuleapSCMSource) source;
-    }
-
-    public void sendBuildStatusToTuleap(Run<?, ?> build, PrintStream logger, TuleapBuildStatus status) {
-        final TuleapSCMSource source = getTuleapSCMSource(build);
-        if (source == null) {
-            // Not a TuleapSCMSource, abort
-            return;
-        }
-
+    public void sendBuildStatusToTuleap(Run<?, ?> build, PrintStream logger, TuleapBuildStatus status, TuleapSCMSource source) {
         final TuleapAccessToken token = getAccessKey(source);
         if (token == null) {
             throw new RuntimeException(

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapCommitNotificationTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapCommitNotificationTrait.java
@@ -1,0 +1,66 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.trait;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.tuleap_git_branch_source.Messages;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceContext;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class TuleapCommitNotificationTrait extends SCMSourceTrait {
+    @DataBoundConstructor
+    public TuleapCommitNotificationTrait() {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        TuleapSCMSourceContext tuleapSourceContext = (TuleapSCMSourceContext) context;
+        tuleapSourceContext.notifyPullRequest(true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category.isUncategorized();
+    }
+
+    @Symbol("tuleapNotifyPullRequest")
+    @Extension
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.TuleapCommitNotificationTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return TuleapSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return TuleapSCMSource.class;
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -9,4 +9,6 @@ BranchSCMHead.pronoun=Branch
 
 TuleapBranchDiscoveryTrait.displayName=Tuleap branches autodiscovery
 
+TuleapCommitNotificationTrait.displayName=Notify build status to Tuleap
+
 WildcardSCMSourceFilterTrait.displayName=Filter repositories by name (wildcards)

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusHandlerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusHandlerTest.java
@@ -1,0 +1,152 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.notify;
+
+import com.google.common.collect.ImmutableList;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+import hudson.scm.ChangeLogParser;
+import hudson.scm.SCM;
+import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
+import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapGitRepository;
+import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapProject;
+import jenkins.scm.api.*;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapCommitNotificationTrait;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+
+public class TuleapPipelineStatusHandlerTest {
+
+    private TuleapPipelineStatusNotifier notifier;
+    private MockedStatic<SCMSource.SourceByItem> sourceByItem;
+
+    private TuleapPipelineStatusHandler handler;
+
+    @Before
+    public void setUp() {
+        this.notifier = Mockito.mock(TuleapPipelineStatusNotifier.class);
+        this.sourceByItem = Mockito.mockStatic(SCMSource.SourceByItem.class);
+
+        this.handler = new TuleapPipelineStatusHandler(this.notifier);
+    }
+
+    @After
+    public void tearDown() {
+        this.sourceByItem.close();
+    }
+
+    @Test
+    public void testItDoesNothingWhenTheSCMSourceIsNotATuleapSCMSource() {
+        final FreeStyleBuild build = mock(FreeStyleBuild.class);
+        final SCMSource source = new SCMSource() {
+            @Override
+            protected void retrieve(SCMSourceCriteria criteria, @NotNull SCMHeadObserver observer, SCMHeadEvent<?> event, @NotNull TaskListener listener) throws IOException, InterruptedException {
+            }
+
+            @NotNull
+            @Override
+            public SCM build(@NotNull SCMHead head, SCMRevision revision) {
+                return new SCM() {
+                    @Override
+                    public ChangeLogParser createChangeLogParser() {
+                        return null;
+                    }
+                };
+            }
+        };
+
+        List<SCMSourceTrait> traits = Collections.singletonList(new TuleapCommitNotificationTrait());
+        source.setTraits(traits);
+
+        final PrintStream logger = mock(PrintStream.class);
+        final FreeStyleProject freestyleProject = mock(FreeStyleProject.class);
+
+        when(build.getParent()).thenReturn(freestyleProject);
+
+        this.sourceByItem.when(() -> SCMSource.SourceByItem.findSource(freestyleProject)).thenReturn(source);
+
+        this.handler.handleCommitNotification(
+            build,
+            logger,
+            TuleapBuildStatus.success
+        );
+
+        verify(this.notifier, never()).sendBuildStatusToTuleap(
+            eq(build),
+            eq(logger),
+            eq(TuleapBuildStatus.success),
+            any()
+        );
+    }
+
+    @Test
+    public void testItDoesNothingWhenTheTraitsIsNotSet() {
+        final FreeStyleBuild build = mock(FreeStyleBuild.class);
+        final TuleapSCMSource source = new TuleapSCMSource(new TuleapProject(), new TuleapGitRepository());
+
+        List<SCMSourceTrait> traits = Collections.emptyList();
+        source.setTraits(traits);
+
+        final PrintStream logger = mock(PrintStream.class);
+        final FreeStyleProject freestyleProject = mock(FreeStyleProject.class);
+
+        when(build.getParent()).thenReturn(freestyleProject);
+
+        this.sourceByItem.when(() -> SCMSource.SourceByItem.findSource(freestyleProject)).thenReturn(source);
+
+        this.handler.handleCommitNotification(
+            build,
+            logger,
+            TuleapBuildStatus.success
+        );
+
+        verify(this.notifier, never()).sendBuildStatusToTuleap(
+            build,
+            logger,
+            TuleapBuildStatus.success,
+            source
+        );
+    }
+
+    @Test
+    public void testItDoesNothingWhenTheCommitNotificationTraitsIsNotSet() {
+        final FreeStyleBuild build = mock(FreeStyleBuild.class);
+        final TuleapSCMSource source = new TuleapSCMSource(new TuleapProject(), new TuleapGitRepository());
+
+        List<SCMSourceTrait> traits = Collections.singletonList(new TuleapCommitNotificationTrait());
+        source.setTraits(traits);
+
+        final PrintStream logger = mock(PrintStream.class);
+        final FreeStyleProject freestyleProject = mock(FreeStyleProject.class);
+
+        when(build.getParent()).thenReturn(freestyleProject);
+
+        this.sourceByItem.when(() -> SCMSource.SourceByItem.findSource(freestyleProject)).thenReturn(source);
+
+        this.handler.handleCommitNotification(
+            build,
+            logger,
+            TuleapBuildStatus.success
+        );
+
+        verify(this.notifier, atMostOnce()).sendBuildStatusToTuleap(
+            build,
+            logger,
+            TuleapBuildStatus.success,
+            source
+        );
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifierTest.java
@@ -1,7 +1,5 @@
-package org.jenkinsci.plugins.tuleap_git_branch_source;
+package org.jenkinsci.plugins.tuleap_git_branch_source.notify;
 
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
 import io.jenkins.plugins.tuleap_api.client.GitApi;
@@ -10,7 +8,9 @@ import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapGitRepository;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import jenkins.scm.api.SCMSource;
 import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
 import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConnector;
+import org.jenkinsci.plugins.tuleap_git_branch_source.notify.TuleapPipelineStatusNotifier;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.After;
@@ -46,26 +46,26 @@ public class TuleapPipelineStatusNotifierTest {
         this.tuleapConnector.close();
     }
 
-    @Test
-    public void testItDoesNotNotifyWhenItIsNotATuleapSCMBuild() {
-        final FreeStyleBuild build = mock(FreeStyleBuild.class);
-        final SCMSource source = mock(SCMSource.class);
-        final PrintStream logger = mock(PrintStream.class);
-        final FreeStyleProject freestyleProject = mock(FreeStyleProject.class);
-
-        when(build.getParent()).thenReturn(freestyleProject);
-
-        this.sourceByItem.when(() -> SCMSource.SourceByItem.findSource(freestyleProject)).thenReturn(source);
-
-        verify(this.gitApi, never()).sendBuildStatus(
-            "5",
-            "aeiouy123456",
-            TuleapBuildStatus.success,
-            this.accessKey
-        );
-
-        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success);
-    }
+//    @Test
+//    public void testItDoesNotNotifyWhenItIsNotATuleapSCMBuild() {
+//        final FreeStyleBuild build = mock(FreeStyleBuild.class);
+//        final SCMSource source = mock(SCMSource.class);
+//        final PrintStream logger = mock(PrintStream.class);
+//        final FreeStyleProject freestyleProject = mock(FreeStyleProject.class);
+//
+//        when(build.getParent()).thenReturn(freestyleProject);
+//
+//        this.sourceByItem.when(() -> SCMSource.SourceByItem.findSource(freestyleProject)).thenReturn(source);
+//
+//        verify(this.gitApi, never()).sendBuildStatus(
+//            "5",
+//            "aeiouy123456",
+//            TuleapBuildStatus.success,
+//            this.accessKey
+//        );
+//
+//        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success);
+//    }
 
     @Test(expected = RuntimeException.class)
     public void testItThrowsAnExceptionWhenAccessKeyNotFound() {
@@ -90,7 +90,7 @@ public class TuleapPipelineStatusNotifierTest {
             this.accessKey
         );
 
-        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success);
+        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success, source);
     }
 
     @Test(expected = RuntimeException.class)
@@ -118,7 +118,7 @@ public class TuleapPipelineStatusNotifierTest {
             this.accessKey
         );
 
-        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success);
+        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success, source);
     }
 
     @Test
@@ -156,6 +156,6 @@ public class TuleapPipelineStatusNotifierTest {
             accessKey
         );
 
-        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success);
+        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success, source);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifierTest.java
@@ -10,7 +10,6 @@ import jenkins.scm.api.SCMSource;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
 import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapConnector;
-import org.jenkinsci.plugins.tuleap_git_branch_source.notify.TuleapPipelineStatusNotifier;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.After;
@@ -45,27 +44,6 @@ public class TuleapPipelineStatusNotifierTest {
         this.sourceByItem.close();
         this.tuleapConnector.close();
     }
-
-//    @Test
-//    public void testItDoesNotNotifyWhenItIsNotATuleapSCMBuild() {
-//        final FreeStyleBuild build = mock(FreeStyleBuild.class);
-//        final SCMSource source = mock(SCMSource.class);
-//        final PrintStream logger = mock(PrintStream.class);
-//        final FreeStyleProject freestyleProject = mock(FreeStyleProject.class);
-//
-//        when(build.getParent()).thenReturn(freestyleProject);
-//
-//        this.sourceByItem.when(() -> SCMSource.SourceByItem.findSource(freestyleProject)).thenReturn(source);
-//
-//        verify(this.gitApi, never()).sendBuildStatus(
-//            "5",
-//            "aeiouy123456",
-//            TuleapBuildStatus.success,
-//            this.accessKey
-//        );
-//
-//        this.notifier.sendBuildStatusToTuleap(build, logger, TuleapBuildStatus.success);
-//    }
 
     @Test(expected = RuntimeException.class)
     public void testItThrowsAnExceptionWhenAccessKeyNotFound() {


### PR DESCRIPTION
[request #21858](https://tuleap.net/plugins/tracker/?tracker=140&aid=21858) Notifying Tuleap should not be systematic

How to test:
 - In your job configuration you now can add or remove the new behaviors: `Notify build status to Tuleap`
If the trait is selected then Jenkins will notify Tuleap.
If the traits is not selected then nothing will be done. Nothing will be
print in the Jenkins console of the build

This traits is not enabled by default, you have to select it if you want
notify Tuleap.
