### PR TITLE
feat: Rework the creation of the Tuleap SCM Source job.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>tuleap-api</artifactId>
-      <version>2.2.0</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.9.0</version>
+      <version>2.10.0</version>
       <scope>compile</scope>
     </dependency>
     <!-- tests -->

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapBranchSCMRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapBranchSCMRevision.java
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMHead;
+
+public class TuleapBranchSCMRevision extends AbstractGitSCMSource.SCMRevisionImpl {
+    public TuleapBranchSCMRevision(SCMHead head, String hash) {
+        super(head, hash);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFile.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFile.java
@@ -1,0 +1,149 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_api.client.GitFileContent;
+import io.jenkins.plugins.tuleap_api.client.GitTreeContent;
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.FileContentNotFoundException;
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.TreeNotFoundException;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import jenkins.scm.api.SCMFile;
+
+public class TuleapSCMFile extends SCMFile {
+
+    private final GitApi gitApi;
+    private final String repositoryId;
+    private final String ref;
+    private final TuleapAccessToken tuleapAccessToken;
+    private final boolean isDirectory;
+
+    public TuleapSCMFile(GitApi gitApi, String repositoryId, String ref, TuleapAccessToken tuleapAccessToken) {
+        super();
+        this.gitApi = gitApi;
+        this.repositoryId = repositoryId;
+        this.ref = ref;
+        this.tuleapAccessToken = tuleapAccessToken;
+
+        this.isDirectory = true;
+        this.type(Type.DIRECTORY);
+    }
+
+    private TuleapSCMFile(TuleapSCMFile parent, String name, Type type) {
+        super(parent, name);
+        this.gitApi = parent.gitApi;
+        this.repositoryId = parent.repositoryId;
+        this.tuleapAccessToken = parent.tuleapAccessToken;
+        this.ref = parent.ref;
+        this.isDirectory = type == Type.DIRECTORY;
+        this.type(type);
+    }
+
+    private TuleapSCMFile(TuleapSCMFile parent, String name, Boolean isDirectory) {
+        super(parent, name);
+        this.gitApi = parent.gitApi;
+        this.tuleapAccessToken = parent.tuleapAccessToken;
+        this.repositoryId = parent.repositoryId;
+        this.ref = parent.ref;
+        this.isDirectory = isDirectory;
+    }
+
+
+    @NonNull
+    @Override
+    protected SCMFile newChild(@NonNull String name, boolean isDirectory) {
+        return new TuleapSCMFile(this, name, isDirectory);
+    }
+
+    @NonNull
+    @Override
+    public Iterable<SCMFile> children() throws IOException, InterruptedException {
+        if (!this.isDirectory()) {
+            throw new IOException("Cannot get children from a regular file");
+        }
+
+        List<GitTreeContent> treeContent;
+        try {
+            treeContent = this.fetchTree();
+        } catch (TreeNotFoundException e) {
+            throw new IOException("Tree content cannot be retrieved: " + e.getMessage());
+        }
+        return treeContent
+            .stream()
+            .map(item -> {
+                Type type;
+
+                switch (item.getType()) {
+                    case TREE:
+                        type = Type.DIRECTORY;
+                        break;
+                    case BLOB:
+                        type = Type.REGULAR_FILE;
+                        break;
+                    case SYMLINK:
+                        type = Type.LINK;
+                        break;
+                    default:
+                        type = Type.OTHER;
+                }
+
+                return new TuleapSCMFile(this, item.getName(), type);
+            })
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public long lastModified() throws IOException, InterruptedException {
+        // Unsupported
+        return 0L;
+    }
+
+    @NonNull
+    @Override
+    protected Type type() throws IOException, InterruptedException {
+        if (isDirectory) {
+            return Type.DIRECTORY;
+        }
+        try {
+            this.gitApi.getFileContent(this.repositoryId, this.ref, this.getPath(), this.tuleapAccessToken);
+            return Type.REGULAR_FILE;
+        } catch (FileContentNotFoundException e) {
+            try {
+                this.gitApi.getTree(repositoryId, ref, this.getPath(), tuleapAccessToken);
+                return Type.DIRECTORY;
+            } catch (TreeNotFoundException treeNotFoundException) {
+                return Type.NONEXISTENT;
+            }
+        }
+    }
+
+    @NonNull
+    @Override
+    public InputStream content() throws IOException, InterruptedException {
+        if (this.isDirectory()) {
+            throw new IOException("Cannot get raw content from a directory");
+        }
+        try {
+            byte[] decodedByteContent = Base64.getDecoder().decode(this.fetchFile().getContent());
+            return new ByteArrayInputStream(decodedByteContent);
+        } catch (FileContentNotFoundException e) {
+            throw new IOException("File not found: " + e.getMessage());
+        }
+    }
+
+    private List<GitTreeContent> fetchTree() throws TreeNotFoundException {
+        return gitApi.getTree(repositoryId, ref, this.getPath(), tuleapAccessToken);
+    }
+
+    private GitFileContent fetchFile() throws FileContentNotFoundException {
+        return this.gitApi.getFileContent(this.repositoryId, this.ref, this.getPath(), this.tuleapAccessToken);
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileSystem.java
@@ -1,0 +1,99 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.config;
+
+import com.google.inject.Guice;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
+import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_api.client.TuleapApiGuiceModule;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import jenkins.scm.api.*;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapBranchSCMHead;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public class TuleapSCMFileSystem extends SCMFileSystem {
+
+    private GitApi gitApi;
+    private final String repositoryId;
+    private final String commitReference;
+    private TuleapAccessToken tuleapAccessToken;
+
+    protected TuleapSCMFileSystem(GitApi gitApi, String repositoryId, String commitReference, TuleapAccessToken tuleapAccessToken, SCMRevision rev) {
+        super(rev);
+        this.gitApi = gitApi;
+        this.repositoryId = repositoryId;
+        this.commitReference = commitReference;
+        this.tuleapAccessToken = tuleapAccessToken;
+    }
+
+    @Override
+    public long lastModified() throws IOException, InterruptedException {
+        return this.gitApi.getCommit(this.repositoryId, this.commitReference, this.tuleapAccessToken).getCommitDate().toInstant().toEpochMilli();
+    }
+
+    @NotNull
+    @Override
+    public SCMFile getRoot() {
+        return new TuleapSCMFile(this.gitApi, this.repositoryId, this.commitReference, this.tuleapAccessToken);
+    }
+
+    @Extension
+    public static class BuilderImpl extends Builder {
+
+        private GitApi getGitApi() {
+            return Guice.createInjector(new TuleapApiGuiceModule()).getInstance(GitApi.class);
+        }
+
+        @Override
+        public boolean supports(SCM source) {
+            return false;
+        }
+
+        @Override
+        public boolean supports(SCMSource source) {
+            return source instanceof TuleapSCMSource;
+        }
+
+        @Override
+        protected boolean supportsDescriptor(SCMDescriptor descriptor) {
+            return false;
+        }
+
+        @Override
+        protected boolean supportsDescriptor(SCMSourceDescriptor descriptor) {
+            return descriptor instanceof TuleapSCMSource.DescriptorImpl;
+        }
+
+        @Override
+        public SCMFileSystem build(@NotNull Item owner, @NotNull SCM scm, SCMRevision rev) throws IOException, InterruptedException {
+            return null;
+        }
+
+        @Override
+        public SCMFileSystem build(@NonNull SCMSource source, @NonNull SCMHead head,
+                                   @CheckForNull SCMRevision rev) {
+            GitApi gitApi =  this.getGitApi();
+            TuleapSCMSource tuleapSCMSource = (TuleapSCMSource) source;
+            TuleapAccessToken tuleapAccessToken = this.getAccessKey(tuleapSCMSource);
+            if (!(head instanceof TuleapBranchSCMHead)) {
+                return null;
+            }
+            String ref = head.getName();
+            return new TuleapSCMFileSystem(gitApi, Integer.toString(tuleapSCMSource.getTuleapGitRepository().getId()), ref, tuleapAccessToken, rev);
+        }
+
+        private TuleapAccessToken getAccessKey(TuleapSCMSource source) {
+            return TuleapConnector.lookupScanCredentials(
+                source.getOwner(),
+                source.getApiBaseUri(),
+                source.getCredentialsId()
+            );
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileTest.java
@@ -1,0 +1,227 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.config;
+
+import com.google.common.collect.ImmutableList;
+import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_api.client.GitCommit;
+import io.jenkins.plugins.tuleap_api.client.GitFileContent;
+import io.jenkins.plugins.tuleap_api.client.GitTreeContent;
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.FileContentNotFoundException;
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.TreeNotFoundException;
+import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import jenkins.scm.api.SCMFile;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.tuleap_git_branch_source.stubs.GitFileContentStub;
+import org.jenkinsci.plugins.tuleap_git_branch_source.stubs.GitTreeContentStub;
+import org.jenkinsci.plugins.tuleap_git_branch_source.stubs.TuleapAccessTokenStub;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class TuleapSCMFileTest {
+
+    @Test(expected = IOException.class)
+    public void iThrowsAnExceptionWhenWeWantToRetrieveTheDirectoryContentWhenTheSCMFileIsAFile() throws IOException, InterruptedException {
+        GitApi gitApi = new GitApi() {
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, StringCredentials stringCredentials) {
+                //do nothing
+            }
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, TuleapAccessToken tuleapAccessToken) {
+                //do nothing
+            }
+
+            @Override
+            public GitCommit getCommit(String s, String s1, TuleapAccessToken tuleapAccessToken) {
+                return null;
+            }
+
+            @Override
+            public List<GitTreeContent> getTree(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws TreeNotFoundException {
+                return null;
+            }
+
+            @Override
+            public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                return null;
+            }
+        };
+        TuleapSCMFile scmRootDirectory = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
+        TuleapSCMFile scmFile = (TuleapSCMFile) scmRootDirectory.newChild("whatever", false);
+
+        scmFile.children();
+    }
+
+    @Test(expected = IOException.class)
+    public void itThrowsAnExceptionIfTheDirectoryIsNotFoundFromTuleap() throws IOException, InterruptedException {
+        GitApi gitApi = new GitApi() {
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, StringCredentials stringCredentials) {
+                //do nothing
+            }
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, TuleapAccessToken tuleapAccessToken) {
+                //do nothing
+            }
+
+            @Override
+            public GitCommit getCommit(String s, String s1, TuleapAccessToken tuleapAccessToken) {
+                return null;
+            }
+
+            @Override
+            public List<GitTreeContent> getTree(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws TreeNotFoundException {
+                throw new TreeNotFoundException();
+            }
+
+            @Override
+            public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                return null;
+            }
+        };
+        TuleapSCMFile tuleapSCMFile = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
+        tuleapSCMFile.children();
+    }
+
+    @Test
+    public void itReturnsTheContentOfTheWantedDirectory() throws IOException, InterruptedException {
+        GitTreeContent file1 = new GitTreeContentStub("1", "tchiki tchiki", "tchiki tchiki", "file", "100644");
+        GitTreeContent file2 = new GitTreeContentStub("2", "naha", "naha", "file", "100644");
+        GitTreeContent tree = new GitTreeContentStub("3", "the world chico", "the world chico", "dir", "040000");
+        GitTreeContent symlink = new GitTreeContentStub("4", "linkz", "linkz", "link", "120000");
+
+        GitApi gitApi = new GitApi() {
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, StringCredentials stringCredentials) {
+                //do nothing
+            }
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, TuleapAccessToken tuleapAccessToken) {
+                //do nothing
+            }
+
+            @Override
+            public GitCommit getCommit(String s, String s1, TuleapAccessToken tuleapAccessToken) {
+                return null;
+            }
+
+            @Override
+            public List<GitTreeContent> getTree(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws TreeNotFoundException {
+                return ImmutableList.of(file1, file2, tree, symlink);
+            }
+
+            @Override
+            public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                return null;
+            }
+        };
+        TuleapSCMFile tuleapSCMFile = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
+
+        List<GitTreeContent> expectedChildren = ImmutableList.of(file1, file2, tree, symlink);
+        Iterable<SCMFile> children = tuleapSCMFile.children();
+
+        children.forEach(scmFile -> {
+
+            GitTreeContent expectedContent = expectedChildren.stream()
+                .filter(currentContent -> scmFile.getName().equals(currentContent.getName()))
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+
+            assertEquals(expectedContent.getName(), scmFile.getName());
+            assertEquals(expectedContent.getPath(), scmFile.getPath());
+        });
+    }
+
+    @Test
+    public void itReturnsTheDecodedContentOfAFile() throws IOException, InterruptedException {
+        GitApi gitApi = new GitApi() {
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, StringCredentials stringCredentials) {
+                //do nothing
+            }
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, TuleapAccessToken tuleapAccessToken) {
+                //do nothing
+            }
+
+            @Override
+            public GitCommit getCommit(String s, String s1, TuleapAccessToken tuleapAccessToken) {
+                return null;
+            }
+
+            @Override
+            public List<GitTreeContent> getTree(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws TreeNotFoundException {
+                return null;
+            }
+
+            @Override
+            public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                return new GitFileContentStub("SSdtIGhlcmUsIEknbSBub3QgaGVyZQ==");
+            }
+        };
+
+        TuleapSCMFile scmRootDirectory = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
+        TuleapSCMFile fileToDecode = (TuleapSCMFile) scmRootDirectory.newChild("whatever", false);
+
+        String expectedDecodedContent = "I'm here, I'm not here";
+        String decodedContent = new BufferedReader(new InputStreamReader(fileToDecode.content(), StandardCharsets.UTF_8)).readLine();
+
+        assertEquals(expectedDecodedContent, decodedContent);
+    }
+
+    @Test(expected = IOException.class)
+    public void itThrowsAExceptionBecauseWeCannotGetTheTextContentOfADirectory() throws IOException, InterruptedException {
+        TuleapSCMFile scmRootDirectory = new TuleapSCMFile(null, "4", "master", new TuleapAccessTokenStub());
+        scmRootDirectory.content();
+    }
+
+    @Test(expected = IOException.class)
+    public void itThrowsAnExceptionWhenTheFileCannotBeRetrieved() throws IOException, InterruptedException {
+        GitApi gitApi = new GitApi() {
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, StringCredentials stringCredentials) {
+                //do nothing
+            }
+
+            @Override
+            public void sendBuildStatus(String s, String s1, TuleapBuildStatus tuleapBuildStatus, TuleapAccessToken tuleapAccessToken) {
+                //do nothing
+            }
+
+            @Override
+            public GitCommit getCommit(String s, String s1, TuleapAccessToken tuleapAccessToken) {
+                return null;
+            }
+
+            @Override
+            public List<GitTreeContent> getTree(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws TreeNotFoundException {
+                return null;
+            }
+
+            @Override
+            public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                throw new FileContentNotFoundException();
+            }
+        };
+
+        TuleapSCMFile scmRootDirectory = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
+        TuleapSCMFile fileToDecode = (TuleapSCMFile) scmRootDirectory.newChild("whatever", false);
+
+        fileToDecode.content();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/GitFileContentStub.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/GitFileContentStub.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.stubs;
+
+import io.jenkins.plugins.tuleap_api.client.GitFileContent;
+
+public class GitFileContentStub implements GitFileContent {
+
+    private String content;
+
+    public GitFileContentStub(String content){
+        this.content = content;
+    }
+    @Override
+    public String getEncoding() {
+        return "base64";
+    }
+
+    @Override
+    public Integer getSize() {
+        return 10;
+    }
+
+    @Override
+    public String getName() {
+        return "faboulousous";
+    }
+
+    @Override
+    public String getPath() {
+        return "directory/faboulousous";
+    }
+
+    @Override
+    public String getContent() {
+        return this.content;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/GitTreeContentStub.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/GitTreeContentStub.java
@@ -1,0 +1,52 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.stubs;
+
+import io.jenkins.plugins.tuleap_api.client.GitTreeContent;
+
+public class GitTreeContentStub implements GitTreeContent {
+
+    private final String id;
+    private final String name;
+    private final String path;
+    private final String type;
+    private final String mode;
+
+    public GitTreeContentStub(String id, String name, String path, String type, String mode) {
+        this.id = id;
+        this.name = name;
+        this.path = path;
+        this.type = type;
+        this.mode = mode;
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public ContentType getType() {
+        if(this.type.equals("dir")) {
+            return ContentType.TREE;
+        }
+
+        if(this.type.equals("link")) {
+            return ContentType.SYMLINK;
+        }
+        return ContentType.BLOB;
+    }
+
+    @Override
+    public String getMode() {
+        return this.mode;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/TuleapAccessTokenStub.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/TuleapAccessTokenStub.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.stubs;
+
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.util.Secret;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessTokenImpl;
+import org.jetbrains.annotations.NotNull;
+
+public class TuleapAccessTokenStub implements TuleapAccessToken {
+    @NotNull
+    @Override
+    public Secret getToken() {
+        return Secret.fromString("my_t0k3n");
+    }
+
+    @NotNull
+    @Override
+    public Secret getPassword() {
+        return Secret.fromString("d0lph1n");
+    }
+
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "";
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "";
+    }
+
+    @NotNull
+    @Override
+    public String getUsername() {
+        return "Coco";
+    }
+
+    @Override
+    public CredentialsScope getScope() {
+        return CredentialsScope.SYSTEM;
+    }
+
+    @NotNull
+    @Override
+    public CredentialsDescriptor getDescriptor() {
+        return new TuleapAccessTokenImpl.DescriptorImpl();
+    }
+}


### PR DESCRIPTION
Part of [story #18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

The creation of the Tuleap SCM Source in Jenkins is now delegated to a
dedicated SCMProbe and dedicated SCMFileSystem.

No functional changes exepcted.