### PR TITLE
feat: Add the Tuleap Pull Request configuration trait

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -29,6 +29,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapSCMFileSystem;
 import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapBranchDiscoveryTrait;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapPullRequestDiscoveryTrait;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.kohsuke.accmod.Restricted;
@@ -344,7 +345,7 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
         }
 
         public List<SCMSourceTrait> getTraitsDefaults() {
-            return Arrays.asList(new TuleapBranchDiscoveryTrait(), new RefSpecsSCMSourceTrait());
+            return Arrays.asList(new TuleapBranchDiscoveryTrait(), new TuleapPullRequestDiscoveryTrait(), new RefSpecsSCMSourceTrait());
         }
 
         @RequirePOST

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -163,6 +163,9 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
                 }
 
             }
+            if(request.isRetrievePullRequests()){
+                request.listener().getLogger().format("Retrieving pull request for repository at %s %n", repositoryPath);
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
@@ -17,6 +17,8 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
 
     private boolean notifyPullRequest = false;
 
+    private boolean wantPullRequests = false;
+
     public TuleapSCMSourceContext(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
     }
@@ -38,6 +40,8 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
         return this.notifyPullRequest;
     }
 
+    public final boolean wantPullRequests() {return this.wantPullRequests; }
+
     /**
      * Adds a requirement for branch details to any {@link TuleapSCMSourceContext} for this context.
      *
@@ -55,6 +59,12 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
     @NonNull
     public TuleapSCMSourceContext notifyPullRequest(boolean notify) {
         this.notifyPullRequest = this.notifyPullRequest || notify;
+        return this;
+    }
+
+    @NonNull
+    public TuleapSCMSourceContext wantPullRequests(boolean include) {
+        this.wantPullRequests = this.wantPullRequests || include;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
@@ -15,11 +15,14 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
 
     private final boolean notifyPullRequest;
 
+    private final boolean retrievePullRequests;
+
     protected TuleapSCMSourceRequest(@NonNull SCMSource source, @NonNull TuleapSCMSourceContext context,
                                      @CheckForNull TaskListener listener) {
         super(source, context, listener);
 
         this.fetchBranches = context.wantBranches();
+        this.retrievePullRequests = context.wantPullRequests();
         this.notifyPullRequest = context.isNotifyPullRequest();
     }
     public boolean isFetchBranches() {
@@ -28,5 +31,9 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
 
     public boolean isNotifyPullRequest() {
         return this.notifyPullRequest;
+    }
+
+    public boolean isRetrievePullRequests() {
+        return retrievePullRequests;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapPullRequestDiscoveryTrait.java
@@ -14,11 +14,12 @@ import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
 import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class
-TuleapBranchDiscoveryTrait extends SCMSourceTrait {
+public class TuleapPullRequestDiscoveryTrait extends SCMSourceTrait {
 
     @DataBoundConstructor
-    public TuleapBranchDiscoveryTrait() {}
+    public TuleapPullRequestDiscoveryTrait() {
+    }
+
 
     /**
      * {@inheritDoc}
@@ -26,7 +27,7 @@ TuleapBranchDiscoveryTrait extends SCMSourceTrait {
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         TuleapSCMSourceContext tuleapSourceContext = (TuleapSCMSourceContext) context;
-        tuleapSourceContext.wantBranches(true);
+        tuleapSourceContext.wantPullRequests(true);
     }
 
     /**
@@ -37,7 +38,7 @@ TuleapBranchDiscoveryTrait extends SCMSourceTrait {
         return category.isUncategorized();
     }
 
-    @Symbol("tuleapBranchDiscovery")
+    @Symbol("tuleapPullRequestDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
@@ -47,7 +48,7 @@ TuleapBranchDiscoveryTrait extends SCMSourceTrait {
          */
         @Override
         public String getDisplayName() {
-            return Messages.TuleapBranchDiscoveryTrait_displayName();
+            return Messages.TuleapPullRequestDiscoveryTrait_displayName();
         }
 
         /**

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -8,6 +8,7 @@ SCMNavigator.aTuleapProjectIsRequiredWarning=A Tuleap Project is required!
 BranchSCMHead.pronoun=Branch
 
 TuleapBranchDiscoveryTrait.displayName=Tuleap branches autodiscovery
+TuleapPullRequestDiscoveryTrait.displayName=Tuleap Pull Requests autodiscovery
 
 TuleapCommitNotificationTrait.displayName=Notify build status to Tuleap
 

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDefaultConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDefaultConfigurationTest.java
@@ -7,6 +7,7 @@ import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapBranchDiscoveryTrait;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapPullRequestDiscoveryTrait;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -38,7 +39,8 @@ public class TuleapSCMNavigatorDefaultConfigurationTest {
                     hasProperty("includes", is("*")),
                     hasProperty("excludes", is(""))),
                 Matchers.instanceOf(RefSpecsSCMSourceTrait.class),
-                Matchers.instanceOf(TuleapBranchDiscoveryTrait.class)
+                Matchers.instanceOf(TuleapBranchDiscoveryTrait.class),
+                Matchers.instanceOf(TuleapPullRequestDiscoveryTrait.class)
             )
         );
     }


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

This is the introduction of the support of pull request in the plugin.
This contribution add a new configuration trait which allows the user to
retrieve the pull request (or not).

Note: this contribution add the traits only!

How to test:
 - Create or Update a Tuleap job by adding or removing the the `Tuleap
   Pull Requests autodiscovery` configuration trait
 - Launch the scan.
=> If the traits was added, then you should see a sentence in the Tuleap
Jenkins job log which says that the Pull request will be retrieved.
=> If the traits was not added or removed, then no sentence is displayed