### PR TITLE
feat: Be able to retrieve and build a PR from same the origin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.3</version>
+      <version>2.12.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.12.3</version>
+      <version>2.12.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>tuleap-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.10.0</version>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
     <!-- tests -->

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevision.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
+import org.jetbrains.annotations.NotNull;
+
+public class TuleapPullRequestRevision extends ChangeRequestSCMRevision<TuleapPullRequestSCMHead> {
+
+    private final TuleapBranchSCMRevision origin;
+
+    public TuleapPullRequestRevision(@NotNull TuleapPullRequestSCMHead head, @NotNull TuleapBranchSCMRevision target, @NonNull TuleapBranchSCMRevision origin) {
+        super(head, target);
+        this.origin = origin;
+    }
+
+    @Override
+    public boolean equivalent(ChangeRequestSCMRevision<?> revision) {
+        if(!(revision instanceof TuleapPullRequestRevision)){
+            return false;
+        }
+        TuleapPullRequestRevision tlpRevision = (TuleapPullRequestRevision) revision;
+        return this.origin.equals(tlpRevision.getOrigin());
+    }
+
+    @Override
+    protected int _hashCode() {
+        return this.origin.hashCode();
+    }
+
+    public SCMRevision getOrigin() {
+        return origin;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jenkins.plugins.tuleap_api.client.GitPullRequest;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import org.jetbrains.annotations.NotNull;
+
+public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2 {
+
+    private final GitPullRequest pullRequest;
+    private final SCMHeadOrigin origin;
+    private final TuleapBranchSCMHead target;
+
+    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target) {
+        super("TLP-PR-" + pullRequest.getId());
+        this.pullRequest = pullRequest;
+        this.origin = origin;
+        this.target = target;
+    }
+
+    @NotNull
+    @Override
+    public ChangeRequestCheckoutStrategy getCheckoutStrategy() {
+        return ChangeRequestCheckoutStrategy.HEAD;
+    }
+
+    @NotNull
+    @Override
+    public String getOriginName() {
+        return this.pullRequest.getSourceBranch();
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return this.pullRequest.getId();
+    }
+
+    @NonNull
+    @Override
+    public SCMHeadOrigin getOrigin() {
+        return this.origin;
+    }
+
+    @NonNull
+    @Override
+    public SCMHead getTarget() {
+        return this.target;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilder.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.plugins.git.GitSCM;
+import jenkins.plugins.git.GitSCMBuilder;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import org.jetbrains.annotations.NotNull;
+
+public class TuleapSCMBuilder extends GitSCMBuilder<TuleapSCMBuilder> {
+    public TuleapSCMBuilder(@NotNull SCMHead head, SCMRevision revision, @NotNull String remote, String credentialsId) {
+        super(head, revision, remote, credentialsId);
+        withoutRefSpecs();
+        if (head instanceof TuleapPullRequestSCMHead) {
+            TuleapPullRequestSCMHead tuleapPullRequestSCMHead = (TuleapPullRequestSCMHead) head;
+            withRefSpec("+refs/tlpr/" + tuleapPullRequestSCMHead.getId() + "/head:refs/remotes/@{remote}/" + tuleapPullRequestSCMHead.getName());
+        } else {
+            withRefSpec("+refs/heads/" + head.getName() + ":refs/remotes/@{remote}/" + head.getName());
+        }
+    }
+
+    @NonNull
+    @Override
+    public GitSCM build() {
+        final SCMHead head = head();
+        final SCMRevision revision = revision();
+        try {
+            if (head instanceof TuleapPullRequestSCMHead && revision instanceof TuleapPullRequestRevision) {
+                withRevision(((TuleapPullRequestRevision) revision).getOrigin());
+            }
+            return super.build();
+        } finally {
+            withHead(head);
+            withRevision(revision);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -346,9 +346,10 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
         this.credentials = credentials;
     }
 
+    @NotNull
     @Override
     public SCM build(@NonNull SCMHead scmHead, @CheckForNull SCMRevision scmRevision) {
-        return new GitSCMBuilder(scmHead, scmRevision, remoteUrl, credentialsId).withTraits(traits).build();
+        return new TuleapSCMBuilder(scmHead, scmRevision, remoteUrl, credentialsId).withTraits(traits).build();
     }
 
     public List<SCMSourceTrait> getTraits() {

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
@@ -17,7 +17,7 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
 
     private boolean notifyPullRequest = false;
 
-    private boolean wantPullRequests = false;
+    private boolean wantOriginPullRequests = false;
 
     public TuleapSCMSourceContext(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
@@ -40,7 +40,7 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
         return this.notifyPullRequest;
     }
 
-    public final boolean wantPullRequests() {return this.wantPullRequests; }
+    public final boolean wantOriginPullRequests() {return this.wantOriginPullRequests; }
 
     /**
      * Adds a requirement for branch details to any {@link TuleapSCMSourceContext} for this context.
@@ -63,8 +63,8 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
     }
 
     @NonNull
-    public TuleapSCMSourceContext wantPullRequests(boolean include) {
-        this.wantPullRequests = this.wantPullRequests || include;
+    public TuleapSCMSourceContext wantOriginPullRequests(boolean include) {
+        this.wantOriginPullRequests = this.wantOriginPullRequests || include;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
@@ -15,14 +15,14 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
 
     private final boolean notifyPullRequest;
 
-    private final boolean retrievePullRequests;
+    private final boolean retrieveOriginPullRequests;
 
     protected TuleapSCMSourceRequest(@NonNull SCMSource source, @NonNull TuleapSCMSourceContext context,
                                      @CheckForNull TaskListener listener) {
         super(source, context, listener);
 
         this.fetchBranches = context.wantBranches();
-        this.retrievePullRequests = context.wantPullRequests();
+        this.retrieveOriginPullRequests = context.wantOriginPullRequests();
         this.notifyPullRequest = context.isNotifyPullRequest();
     }
     public boolean isFetchBranches() {
@@ -33,7 +33,7 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
         return this.notifyPullRequest;
     }
 
-    public boolean isRetrievePullRequests() {
-        return retrievePullRequests;
+    public boolean isRetrieveOriginPullRequests() {
+        return retrieveOriginPullRequests;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/helpers/TuleapApiRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/helpers/TuleapApiRetriever.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.helpers;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_api.client.PullRequestApi;
+import io.jenkins.plugins.tuleap_api.client.TuleapApiGuiceModule;
+
+public class TuleapApiRetriever {
+
+
+    private static Injector getApiGuiceModule() {
+        return Guice.createInjector(new TuleapApiGuiceModule());
+    }
+
+    public static GitApi getGitApi() {
+        return getApiGuiceModule().getInstance(GitApi.class);
+    }
+
+    public static PullRequestApi getPullRequestApi() {
+        return getApiGuiceModule().getInstance(PullRequestApi.class);
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -8,7 +8,7 @@ SCMNavigator.aTuleapProjectIsRequiredWarning=A Tuleap Project is required!
 BranchSCMHead.pronoun=Branch
 
 TuleapBranchDiscoveryTrait.displayName=Tuleap branches autodiscovery
-TuleapPullRequestDiscoveryTrait.displayName=Tuleap Pull Requests autodiscovery
+TuleapPullRequestDiscoveryTrait.displayName=Tuleap Pull Requests from same origin autodiscovery
 
 TuleapCommitNotificationTrait.displayName=Notify build status to Tuleap
 

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
@@ -1,0 +1,114 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import io.jenkins.plugins.tuleap_api.client.GitHead;
+import io.jenkins.plugins.tuleap_api.client.GitPullRequest;
+import io.jenkins.plugins.tuleap_api.client.GitRepositoryReference;
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
+import org.jenkinsci.plugins.tuleap_git_branch_source.stubs.SomeChangeRequestRevision;
+import org.jenkinsci.plugins.tuleap_git_branch_source.stubs.SomeChangeRequestSCMHead;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TuleapPullRequestRevisionTest {
+
+    @Test
+    public void itReturnsFalseIfTheRevisionIsNotATuleapPRRevision() {
+        TuleapBranchSCMHead targetBranch = new TuleapBranchSCMHead("targeto-branchu");
+        TuleapBranchSCMRevision targetBranchRevision = new TuleapBranchSCMRevision(targetBranch, "t4rg3t_h4sh");
+
+        TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
+        TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
+
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch);
+
+        TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
+
+        assertFalse(tuleapPullRequestRevision.equivalent(this.getNonTuleapChangeRequestRevision(targetBranch.getName())));
+    }
+
+    @Test
+    public void itReturnsTrueIfTheGivenRevisionIsTheWantedRevision() {
+        TuleapBranchSCMHead targetBranch = new TuleapBranchSCMHead("targeto-branchu");
+        TuleapBranchSCMRevision targetBranchRevision = new TuleapBranchSCMRevision(targetBranch, "t4rg3t_h4sh");
+
+        TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
+        TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
+
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch);
+
+        TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
+
+        assertTrue(tuleapPullRequestRevision.equivalent(tuleapPullRequestRevision));
+    }
+
+    @Test
+    public void itReturnsFalseIfTheGivenRevisionIsNotTheWantedRevision() {
+        TuleapBranchSCMHead targetBranch = new TuleapBranchSCMHead("targeto-branchu");
+        TuleapBranchSCMRevision targetBranchRevision = new TuleapBranchSCMRevision(targetBranch, "t4rg3t_h4sh");
+
+        TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
+        TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
+
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch);
+
+        TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
+
+        TuleapBranchSCMHead otherTargetBranch = new TuleapBranchSCMHead("targeto-0th3r-branchu");
+        TuleapBranchSCMRevision otherTargetBranchRevision = new TuleapBranchSCMRevision(otherTargetBranch, "t4rg3t_h4sh_-0th3r");
+
+        TuleapBranchSCMHead otherOriginBranch = new TuleapBranchSCMHead("origino-0th3r-branchu");
+        TuleapBranchSCMRevision otherOriginBranchRevision = new TuleapBranchSCMRevision(otherOriginBranch, "0r1g4n_h4sh_-0th3r");
+
+        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch);
+
+        TuleapPullRequestRevision otherPullRequestRevision = new TuleapPullRequestRevision(otherPullRequestSCMHead, otherTargetBranchRevision,otherOriginBranchRevision);
+        assertFalse(tuleapPullRequestRevision.equivalent(otherPullRequestRevision));
+    }
+
+    private ChangeRequestSCMRevision<?> getNonTuleapChangeRequestRevision(String headName) {
+        SomeChangeRequestSCMHead headTarget = new SomeChangeRequestSCMHead(headName);
+        SCMRevision target = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(headName), headName);
+        return new SomeChangeRequestRevision(headTarget, target);
+    }
+
+
+    private GitPullRequest getGitPullRequest() {
+        return new GitPullRequest() {
+            @Override
+            public String getId() {
+                return null;
+            }
+
+            @Override
+            public GitRepositoryReference getSourceRepository() {
+                return null;
+            }
+
+            @Override
+            public GitRepositoryReference getDestinationRepository() {
+                return null;
+            }
+
+            @Override
+            public String getSourceBranch() {
+                return null;
+            }
+
+            @Override
+            public String getDestinationBranch() {
+                return null;
+            }
+
+            @Override
+            public GitHead getHead() {
+                return null;
+            }
+        };
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
@@ -1,0 +1,114 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import io.jenkins.plugins.tuleap_api.client.GitHead;
+import io.jenkins.plugins.tuleap_api.client.GitPullRequest;
+import io.jenkins.plugins.tuleap_api.client.GitRepositoryReference;
+import jenkins.scm.api.SCMHeadOrigin;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+
+public class TuleapSCMBuilderTest {
+
+    @Test
+    public void testItCleansAndAddTheBranchRefSpecByDefault() {
+        TuleapBranchSCMHead tlpScmHead = new TuleapBranchSCMHead("jcomprendspas-branch");
+        TuleapBranchSCMRevision tlpRevision = new TuleapBranchSCMRevision(tlpScmHead, "h4sh_branch");
+        String remote = "https://tuleap.example.com/repo.git";
+        String credentialsId = "1581";
+
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpScmHead, tlpRevision, remote, credentialsId);
+        assertEquals(1, tuleapSCMBuilder.refSpecs().size());
+        assertEquals("+refs/heads/jcomprendspas-branch:refs/remotes/@{remote}/jcomprendspas-branch", tuleapSCMBuilder.refSpecs().get(0));
+        assertEquals("https://tuleap.example.com/repo.git", tuleapSCMBuilder.remote());
+    }
+
+    @Test
+    public void testItCleansAndAddThePullRequestBranchRefSpecWhenThereIsAPullRequest() {
+        TuleapBranchSCMHead tlpScmHeadTarget = new TuleapBranchSCMHead("naha");
+        TuleapBranchSCMRevision tlpRevisionTarget = new TuleapBranchSCMRevision(tlpScmHeadTarget, "h4sh_t4rg3t");
+
+        TuleapBranchSCMHead tlpScmHeadOrigin = new TuleapBranchSCMHead("tchiki-tchiki");
+        TuleapBranchSCMRevision tlpRevisionOrigin = new TuleapBranchSCMRevision(tlpScmHeadOrigin, "h4shu_or1g1n");
+
+        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget);
+        TuleapPullRequestRevision tlpPrRevision = new TuleapPullRequestRevision(tlpPrScmHead, tlpRevisionTarget, tlpRevisionOrigin);
+
+        String remote = "https://tuleap.example.com/repo.git";
+        String credentialsId = "1581";
+
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId);
+        assertEquals(1, tuleapSCMBuilder.refSpecs().size());
+        assertEquals("+refs/tlpr/3/head:refs/remotes/@{remote}/TLP-PR-3", tuleapSCMBuilder.refSpecs().get(0));
+        assertEquals("https://tuleap.example.com/repo.git", tuleapSCMBuilder.remote());
+    }
+
+    @Test
+    public void testItReturnsAGitSCMWithTheOriginRevisionWhenThereIsATuleapPullRequest() {
+        TuleapPullRequestSCMHead tlpPrScmHead = mock(TuleapPullRequestSCMHead.class);
+        when(tlpPrScmHead.getName()).thenReturn("some_branch");
+        TuleapPullRequestRevision tlpPrRevision = mock(TuleapPullRequestRevision.class);
+
+        String remote = "https://tuleap.example.com/repo.git";
+        String credentialsId = "1581";
+
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId);
+
+        tuleapSCMBuilder.build();
+        verify(tlpPrRevision, atLeastOnce()).getOrigin();
+        assertEquals(tlpPrRevision, tuleapSCMBuilder.revision());
+    }
+
+    @Test
+    public void testItReturnsAGitSCMWithTheBaseRevisionWhenThereIsNoTuleapPullRequest() {
+        TuleapBranchSCMHead tlpScmHead = mock(TuleapBranchSCMHead.class);
+        when(tlpScmHead.getName()).thenReturn("some_branch");
+        TuleapBranchSCMRevision tlpRevision = mock(TuleapBranchSCMRevision.class);
+        when(tlpRevision.getHash()).thenReturn("38dfa09a67d7872d821b6a46eff340bc8ae0af0f");
+        when(tlpRevision.getHead()).thenReturn(tlpScmHead);
+
+        String remote = "https://tuleap.example.com/repo.git";
+        String credentialsId = "1581";
+
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpScmHead, tlpRevision, remote, credentialsId);
+
+        tuleapSCMBuilder.build();
+        assertEquals(tlpRevision, tuleapSCMBuilder.revision());
+    }
+
+    private GitPullRequest getPullRequest() {
+        return new GitPullRequest() {
+            @Override
+            public String getId() {
+                return "3";
+            }
+
+            @Override
+            public GitRepositoryReference getSourceRepository() {
+                return null;
+            }
+
+            @Override
+            public GitRepositoryReference getDestinationRepository() {
+                return null;
+            }
+
+            @Override
+            public String getSourceBranch() {
+                return "naha";
+            }
+
+            @Override
+            public String getDestinationBranch() {
+                return null;
+            }
+
+            @Override
+            public GitHead getHead() {
+                return null;
+            }
+        };
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDefaultConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDefaultConfigurationTest.java
@@ -7,7 +7,7 @@ import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapBranchDiscoveryTrait;
-import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapPullRequestDiscoveryTrait;
+import org.jenkinsci.plugins.tuleap_git_branch_source.trait.TuleapOriginPullRequestDiscoveryTrait;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -40,7 +40,7 @@ public class TuleapSCMNavigatorDefaultConfigurationTest {
                     hasProperty("excludes", is(""))),
                 Matchers.instanceOf(RefSpecsSCMSourceTrait.class),
                 Matchers.instanceOf(TuleapBranchDiscoveryTrait.class),
-                Matchers.instanceOf(TuleapPullRequestDiscoveryTrait.class)
+                Matchers.instanceOf(TuleapOriginPullRequestDiscoveryTrait.class)
             )
         );
     }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContextTest.java
@@ -1,8 +1,15 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source;
 
+import hudson.model.TaskListener;
 import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+
+import java.io.IOException;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TuleapSCMSourceContextTest {
 
@@ -10,5 +17,32 @@ public class TuleapSCMSourceContextTest {
     public void testDefaultContext() {
         TuleapSCMSourceContext tuleapSourceContext = new TuleapSCMSourceContext(null, SCMHeadObserver.none());
         assertFalse(tuleapSourceContext.wantBranches());
+    }
+
+    @Test
+    public void testWeDoesNotWantToRetrieveOriginPullRequest(){
+        SCMSourceCriteria criteria = new SCMSourceCriteria() {
+            @Override
+            public boolean isHead(@NotNull Probe probe, @NotNull TaskListener listener) throws IOException {
+                return false;
+            }
+        };
+        TuleapSCMSourceContext context = new TuleapSCMSourceContext(criteria, SCMHeadObserver.none());
+
+        context.wantOriginPullRequests(false);
+        assertFalse(context.wantOriginPullRequests());
+    }
+    @Test
+    public void testWeWantToRetrieveOriginPullRequest(){
+        SCMSourceCriteria criteria = new SCMSourceCriteria() {
+            @Override
+            public boolean isHead(@NotNull Probe probe, @NotNull TaskListener listener) throws IOException {
+                return false;
+            }
+        };
+        TuleapSCMSourceContext context = new TuleapSCMSourceContext(criteria, SCMHeadObserver.none());
+
+        context.wantOriginPullRequests(true);
+        assertTrue(context.wantOriginPullRequests());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileTest.java
@@ -1,10 +1,7 @@
 package org.jenkinsci.plugins.tuleap_git_branch_source.config;
 
 import com.google.common.collect.ImmutableList;
-import io.jenkins.plugins.tuleap_api.client.GitApi;
-import io.jenkins.plugins.tuleap_api.client.GitCommit;
-import io.jenkins.plugins.tuleap_api.client.GitFileContent;
-import io.jenkins.plugins.tuleap_api.client.GitTreeContent;
+import io.jenkins.plugins.tuleap_api.client.*;
 import io.jenkins.plugins.tuleap_api.client.exceptions.git.FileContentNotFoundException;
 import io.jenkins.plugins.tuleap_api.client.exceptions.git.TreeNotFoundException;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
@@ -54,6 +51,11 @@ public class TuleapSCMFileTest {
             public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
                 return null;
             }
+
+            @Override
+            public List<GitPullRequest> getPullRequests(String repositoryId, TuleapAccessToken token) {
+                return null;
+            }
         };
         TuleapSCMFile scmRootDirectory = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
         TuleapSCMFile scmFile = (TuleapSCMFile) scmRootDirectory.newChild("whatever", false);
@@ -86,6 +88,11 @@ public class TuleapSCMFileTest {
 
             @Override
             public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                return null;
+            }
+
+            @Override
+            public List<GitPullRequest> getPullRequests(String repositoryId, TuleapAccessToken token) {
                 return null;
             }
         };
@@ -124,6 +131,11 @@ public class TuleapSCMFileTest {
 
             @Override
             public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
+                return null;
+            }
+
+            @Override
+            public List<GitPullRequest> getPullRequests(String repositoryId, TuleapAccessToken token) {
                 return null;
             }
         };
@@ -172,6 +184,11 @@ public class TuleapSCMFileTest {
             public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
                 return new GitFileContentStub("SSdtIGhlcmUsIEknbSBub3QgaGVyZQ==");
             }
+
+            @Override
+            public List<GitPullRequest> getPullRequests(String repositoryId, TuleapAccessToken token) {
+                return null;
+            }
         };
 
         TuleapSCMFile scmRootDirectory = new TuleapSCMFile(gitApi, "4", "master", new TuleapAccessTokenStub());
@@ -216,6 +233,11 @@ public class TuleapSCMFileTest {
             @Override
             public GitFileContent getFileContent(String s, String s1, String s2, TuleapAccessToken tuleapAccessToken) throws FileContentNotFoundException {
                 throw new FileContentNotFoundException();
+            }
+
+            @Override
+            public List<GitPullRequest> getPullRequests(String repositoryId, TuleapAccessToken token) {
+                return null;
             }
         };
 

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/SomeChangeRequestRevision.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/SomeChangeRequestRevision.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.stubs;
+
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
+import org.jetbrains.annotations.NotNull;
+
+public class SomeChangeRequestRevision extends ChangeRequestSCMRevision<SomeChangeRequestSCMHead> {
+    public SomeChangeRequestRevision(@NotNull SomeChangeRequestSCMHead head, @NotNull SCMRevision target) {
+        super(head, target);
+    }
+
+    @Override
+    public boolean equivalent(ChangeRequestSCMRevision<?> revision) {
+        return true;
+    }
+
+    @Override
+    protected int _hashCode() {
+        return 0;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/SomeChangeRequestSCMHead.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/SomeChangeRequestSCMHead.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.stubs;
+
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import org.jetbrains.annotations.NotNull;
+
+public class SomeChangeRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2 {
+
+    public SomeChangeRequestSCMHead(@NotNull String name) {
+        super(name);
+    }
+
+    @NotNull
+    @Override
+    public ChangeRequestCheckoutStrategy getCheckoutStrategy() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public String getOriginName() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public SCMHead getTarget() {
+        return new SCMHead(getName());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
@@ -1,0 +1,104 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.unit;
+
+import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
+import io.jenkins.plugins.tuleap_api.client.GitHead;
+import io.jenkins.plugins.tuleap_api.client.GitPullRequest;
+import io.jenkins.plugins.tuleap_api.client.GitRepositoryReference;
+import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapGitRepository;
+import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapProject;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.SCMRevision;
+import org.jenkinsci.plugins.tuleap_git_branch_source.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+
+
+public class TuleapSCMSourceTest {
+
+    @Test
+    public void itReturnsTheGivenRevisionIfThisIsNotATuleapSCMRevision() throws IOException, InterruptedException {
+        SCMHead head = new SCMHead("dummy head");
+        SCMRevision revision = new SCMRevision(head) {
+            @Override
+            public boolean equals(Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 0;
+            }
+        };
+
+        TaskListener listener = new LogTaskListener(Logger.getLogger(getClass().getName()), Level.FINE);
+
+        TuleapProject project = new TuleapProject();
+        TuleapGitRepository repository = new TuleapGitRepository();
+        TuleapSCMSource tlpSCMSource = new TuleapSCMSource(project, repository);
+
+        SCMRevision resultRevision = tlpSCMSource.getTrustedRevision(revision, listener);
+
+        assertEquals(revision.getHead().getName(), resultRevision.getHead().getName());
+        assertEquals(revision.hashCode(), resultRevision.hashCode());
+    }
+
+    @Test
+    public void itReturnsTheTargetRevisionIfTheSourceRevisionIsNotFromATrustedSource() throws IOException, InterruptedException {
+        GitPullRequest pullRequest = new GitPullRequest() {
+            @Override
+            public String getId() {
+                return null;
+            }
+
+            @Override
+            public GitRepositoryReference getSourceRepository() {
+                return null;
+            }
+
+            @Override
+            public GitRepositoryReference getDestinationRepository() {
+                return null;
+            }
+
+            @Override
+            public String getSourceBranch() {
+                return "source-branch";
+            }
+
+            @Override
+            public String getDestinationBranch() {
+                return null;
+            }
+
+            @Override
+            public GitHead getHead() {
+                return null;
+            }
+        };
+
+        SCMHeadOrigin originHead = SCMHeadOrigin.DEFAULT;
+        TuleapBranchSCMHead targetHead = new TuleapBranchSCMHead("my-c63-tlp-branch");
+        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead);
+
+        TuleapBranchSCMRevision target = new TuleapBranchSCMRevision(head.getTarget(), "h4sH_t4rG3t");
+        TuleapBranchSCMRevision origin = new TuleapBranchSCMRevision(new TuleapBranchSCMHead(head.getOriginName()), "h4sH_or1g1n");
+        TuleapPullRequestRevision revision = new TuleapPullRequestRevision(head, target, origin);
+
+        TaskListener listener = new LogTaskListener(Logger.getLogger(getClass().getName()), Level.FINE);
+
+        TuleapProject project = new TuleapProject();
+        TuleapGitRepository repository = new TuleapGitRepository();
+        TuleapSCMSource tlpSCMSource = new TuleapSCMSource(project, repository);
+
+        SCMRevision resultRevision = tlpSCMSource.getTrustedRevision(revision, listener);
+
+        assertEquals(revision.getTarget().getHead().getName(), resultRevision.getHead().getName());
+    }
+}


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

Pull Request from fork are not supported yet.
This contribution also updates the needed dependencies

How to test:
 - Enable the `Tuleap Pull Requests from origin autodiscovery` trait in
   the configuration menu. Note: By default it should be enable when
creating a new Tuleap job
 - Save the configuration and/or launch the scan
=> You should see the pull requests jobs created of the concerned
repository
=> If a fork is detected then a message is diplayed which said that the
fork are not supported. There is no job created too.
