### PR TITLE
feat: Add the support of Pull Requests from forked repository

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevision.java
@@ -8,10 +8,12 @@ import org.jetbrains.annotations.NotNull;
 public class TuleapPullRequestRevision extends ChangeRequestSCMRevision<TuleapPullRequestSCMHead> {
 
     private final TuleapBranchSCMRevision origin;
+    private final String targetHash;
 
     public TuleapPullRequestRevision(@NotNull TuleapPullRequestSCMHead head, @NotNull TuleapBranchSCMRevision target, @NonNull TuleapBranchSCMRevision origin) {
         super(head, target);
         this.origin = origin;
+        this.targetHash = target.getHash();
     }
 
     @Override
@@ -29,6 +31,10 @@ public class TuleapPullRequestRevision extends ChangeRequestSCMRevision<TuleapPu
     }
 
     public SCMRevision getOrigin() {
-        return origin;
+        return this.origin;
+    }
+
+    public String getTargetHash() {
+        return this.targetHash;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
@@ -14,13 +14,15 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
     private final SCMHeadOrigin origin;
     private final TuleapBranchSCMHead target;
     private final int originRepositoryId;
+    private final Integer targetRepositoryId;
 
-    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target, Integer originRepositoryId) {
+    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target, Integer originRepositoryId, Integer targetRepositoryId) {
         super("TLP-PR-" + pullRequest.getId());
         this.pullRequest = pullRequest;
         this.origin = origin;
         this.target = target;
         this.originRepositoryId = originRepositoryId;
+        this.targetRepositoryId = targetRepositoryId;
     }
 
     @NotNull
@@ -55,5 +57,9 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
 
     public int getOriginRepositoryId() {
         return this.originRepositoryId;
+    }
+
+    public Integer getTargetRepositoryId() {
+        return this.targetRepositoryId;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
@@ -26,7 +26,7 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
     @NotNull
     @Override
     public ChangeRequestCheckoutStrategy getCheckoutStrategy() {
-        return ChangeRequestCheckoutStrategy.MERGE;
+        return ChangeRequestCheckoutStrategy.HEAD;
     }
 
     @NotNull

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
@@ -13,18 +13,20 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
     private final GitPullRequest pullRequest;
     private final SCMHeadOrigin origin;
     private final TuleapBranchSCMHead target;
+    private final int originRepositoryId;
 
-    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target) {
+    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target, Integer originRepositoryId) {
         super("TLP-PR-" + pullRequest.getId());
         this.pullRequest = pullRequest;
         this.origin = origin;
         this.target = target;
+        this.originRepositoryId = originRepositoryId;
     }
 
     @NotNull
     @Override
     public ChangeRequestCheckoutStrategy getCheckoutStrategy() {
-        return ChangeRequestCheckoutStrategy.HEAD;
+        return ChangeRequestCheckoutStrategy.MERGE;
     }
 
     @NotNull
@@ -49,5 +51,9 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
     @Override
     public SCMHead getTarget() {
         return this.target;
+    }
+
+    public int getOriginRepositoryId() {
+        return this.originRepositoryId;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -194,13 +194,15 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
 
                     SCMHeadOrigin origin = SCMHeadOrigin.DEFAULT;
                     Integer originRepositoryId = this.repository.getId();
+                    Integer targetRepositoryId = this.repository.getId();
                     if (isFork) {
                         origin = new SCMHeadOrigin.Fork(pullRequest.getSourceRepository().getName());
                         originRepositoryId = pullRequest.getSourceRepository().getId();
+                        targetRepositoryId = pullRequest.getDestinationRepository().getId();
                     }
                     TuleapBranchSCMHead targetBranch = new TuleapBranchSCMHead(pullRequest.getDestinationBranch());
 
-                    TuleapPullRequestSCMHead tlpPRSCMHead = new TuleapPullRequestSCMHead(pullRequest, origin, targetBranch, originRepositoryId);
+                    TuleapPullRequestSCMHead tlpPRSCMHead = new TuleapPullRequestSCMHead(pullRequest, origin, targetBranch, originRepositoryId, targetRepositoryId);
                     GitCommit targetLastCommit = gitApi.getCommit(Integer.toString(this.repository.getId()), targetBranch.getName(), this.credentials);
                     if (request.process(tlpPRSCMHead,
                         (SCMSourceRequest.RevisionLambda<TuleapPullRequestSCMHead, TuleapPullRequestRevision>) head ->
@@ -292,9 +294,9 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
                 }
             }
             TuleapPullRequestRevision rev = (TuleapPullRequestRevision) revision;
-            listener.getLogger().format("Loading trusted files from target branch %s at %s rather than %s%n",
+            listener.getLogger().format("Loading trusted Jenkins files from target branch %s at %s rather than %s%n",
                 head.getTarget().getName(), rev.getTarget(), rev.getOrigin().getHead().getName());
-            return rev.getTarget();
+            return new SCMRevisionImpl(head.getTarget(), rev.getTargetHash());
         }
         return revision;
     }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceContext.java
@@ -19,6 +19,8 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
 
     private boolean wantOriginPullRequests = false;
 
+    private boolean wantForkPullRequests = false;
+
     public TuleapSCMSourceContext(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
     }
@@ -40,14 +42,19 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
         return this.notifyPullRequest;
     }
 
-    public final boolean wantOriginPullRequests() {return this.wantOriginPullRequests; }
+    public final boolean wantOriginPullRequests() {
+        return this.wantOriginPullRequests;
+    }
+
+    public final boolean wantForkPullRequests() {
+        return this.wantForkPullRequests;
+    }
 
     /**
      * Adds a requirement for branch details to any {@link TuleapSCMSourceContext} for this context.
      *
-     * @param include
-     *            {@code true} to add the requirement or {@code false} to leave the requirement as is (makes simpler
-     *            with method chaining)
+     * @param include {@code true} to add the requirement or {@code false} to leave the requirement as is (makes simpler
+     *                with method chaining)
      * @return {@code this} for method chaining.
      */
     @NonNull
@@ -65,6 +72,12 @@ public class TuleapSCMSourceContext extends SCMSourceContext<TuleapSCMSourceCont
     @NonNull
     public TuleapSCMSourceContext wantOriginPullRequests(boolean include) {
         this.wantOriginPullRequests = this.wantOriginPullRequests || include;
+        return this;
+    }
+
+    @NonNull
+    public TuleapSCMSourceContext wantForkPullRequests(boolean include) {
+        this.wantForkPullRequests = this.wantForkPullRequests || include;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSourceRequest.java
@@ -17,12 +17,15 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
 
     private final boolean retrieveOriginPullRequests;
 
+    private final boolean retrieveForkPullRequests;
+
     protected TuleapSCMSourceRequest(@NonNull SCMSource source, @NonNull TuleapSCMSourceContext context,
                                      @CheckForNull TaskListener listener) {
         super(source, context, listener);
 
         this.fetchBranches = context.wantBranches();
         this.retrieveOriginPullRequests = context.wantOriginPullRequests();
+        this.retrieveForkPullRequests = context.wantForkPullRequests();
         this.notifyPullRequest = context.isNotifyPullRequest();
     }
     public boolean isFetchBranches() {
@@ -35,5 +38,13 @@ public class TuleapSCMSourceRequest extends SCMSourceRequest {
 
     public boolean isRetrieveOriginPullRequests() {
         return retrieveOriginPullRequests;
+    }
+
+    public boolean isRetrieveForkPullRequests() {
+        return retrieveForkPullRequests;
+    }
+
+    public boolean isRetrievePullRequests(){
+        return this.retrieveForkPullRequests || this.retrieveOriginPullRequests;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileSystem.java
@@ -8,7 +8,6 @@ import hudson.model.Item;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import io.jenkins.plugins.tuleap_api.client.GitApi;
-import io.jenkins.plugins.tuleap_api.client.TuleapApiGuiceModule;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import jenkins.scm.api.*;
 import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapBranchSCMHead;
@@ -81,14 +80,19 @@ public class TuleapSCMFileSystem extends SCMFileSystem {
             TuleapAccessToken tuleapAccessToken = this.getAccessKey(tuleapSCMSource);
 
             String ref;
+            String repositoryId;
             if ((head instanceof TuleapBranchSCMHead)) {
                 ref = head.getName();
-            } else if (head instanceof TuleapPullRequestSCMHead) {
-                ref = ((TuleapPullRequestSCMHead) head).getOriginName();
-            } else {
-                return null;
+                repositoryId = Integer.toString(tuleapSCMSource.getTuleapGitRepository().getId());
             }
-            return new TuleapSCMFileSystem(gitApi, Integer.toString(tuleapSCMSource.getTuleapGitRepository().getId()), ref, tuleapAccessToken, rev);
+           else if(head instanceof TuleapPullRequestSCMHead){
+               ref = ((TuleapPullRequestSCMHead) head).getOriginName();
+               repositoryId = Integer.toString(((TuleapPullRequestSCMHead) head).getOriginRepositoryId());
+           } else {
+               return null;
+            }
+
+            return new TuleapSCMFileSystem(gitApi, repositoryId , ref, tuleapAccessToken, rev);
         }
 
         private TuleapAccessToken getAccessKey(TuleapSCMSource source) {

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapForkPullRequestDiscoveryTrait.java
@@ -1,0 +1,90 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.trait;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import jenkins.scm.api.trait.*;
+import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.tuleap_git_branch_source.*;
+import org.jetbrains.annotations.NotNull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+public class TuleapForkPullRequestDiscoveryTrait extends SCMSourceTrait {
+
+    @DataBoundConstructor
+    public TuleapForkPullRequestDiscoveryTrait() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        TuleapSCMSourceContext tuleapSourceContext = (TuleapSCMSourceContext) context;
+        tuleapSourceContext.wantForkPullRequests(true);
+        tuleapSourceContext.withAuthority(new TuleapForkPullRequestDiscoveryTrait.TrustNobody());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category.isUncategorized();
+    }
+
+    @Symbol("tuleapForkPullRequestDiscovery")
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.TuleapForkPullRequestDiscoveryTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return TuleapSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return TuleapSCMSource.class;
+        }
+    }
+
+    public static class TrustNobody extends SCMHeadAuthority<SCMSourceRequest, ChangeRequestSCMHead2, SCMRevision> {
+
+        @Override
+        protected boolean checkTrusted(@NotNull SCMSourceRequest request, @NotNull ChangeRequestSCMHead2 head) throws IOException, InterruptedException {
+            return false;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
+
+            @Override
+            public boolean isApplicableToOrigin(
+                @NonNull Class<? extends SCMHeadOrigin> originClass) {
+                return SCMHeadOrigin.Fork.class.isAssignableFrom(originClass);
+            }
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -9,6 +9,7 @@ BranchSCMHead.pronoun=Branch
 
 TuleapBranchDiscoveryTrait.displayName=Tuleap branches autodiscovery
 TuleapPullRequestDiscoveryTrait.displayName=Tuleap Pull Requests from same origin autodiscovery
+TuleapForkPullRequestDiscoveryTrait.displayName=Tuleap Pull Requests from fork autodiscovery
 
 TuleapCommitNotificationTrait.displayName=Notify build status to Tuleap
 

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
@@ -24,7 +24,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch,101);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 102);
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -39,7 +39,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch,101);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 101);
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -54,7 +54,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 102);
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -64,7 +64,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead otherOriginBranch = new TuleapBranchSCMHead("origino-0th3r-branchu");
         TuleapBranchSCMRevision otherOriginBranchRevision = new TuleapBranchSCMRevision(otherOriginBranch, "0r1g4n_h4sh_-0th3r");
 
-        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch, 101);
+        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch, 101, 102);
 
         TuleapPullRequestRevision otherPullRequestRevision = new TuleapPullRequestRevision(otherPullRequestSCMHead, otherTargetBranchRevision,otherOriginBranchRevision);
         assertFalse(tuleapPullRequestRevision.equivalent(otherPullRequestRevision));

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
@@ -24,7 +24,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch,101);
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -39,7 +39,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch,101);
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -54,7 +54,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101);
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -64,7 +64,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead otherOriginBranch = new TuleapBranchSCMHead("origino-0th3r-branchu");
         TuleapBranchSCMRevision otherOriginBranchRevision = new TuleapBranchSCMRevision(otherOriginBranch, "0r1g4n_h4sh_-0th3r");
 
-        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch);
+        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch, 101);
 
         TuleapPullRequestRevision otherPullRequestRevision = new TuleapPullRequestRevision(otherPullRequestSCMHead, otherTargetBranchRevision,otherOriginBranchRevision);
         assertFalse(tuleapPullRequestRevision.equivalent(otherPullRequestRevision));

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
@@ -33,7 +33,7 @@ public class TuleapSCMBuilderTest {
         TuleapBranchSCMHead tlpScmHeadOrigin = new TuleapBranchSCMHead("tchiki-tchiki");
         TuleapBranchSCMRevision tlpRevisionOrigin = new TuleapBranchSCMRevision(tlpScmHeadOrigin, "h4shu_or1g1n");
 
-        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget);
+        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget,4);
         TuleapPullRequestRevision tlpPrRevision = new TuleapPullRequestRevision(tlpPrScmHead, tlpRevisionTarget, tlpRevisionOrigin);
 
         String remote = "https://tuleap.example.com/repo.git";

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
@@ -33,7 +33,7 @@ public class TuleapSCMBuilderTest {
         TuleapBranchSCMHead tlpScmHeadOrigin = new TuleapBranchSCMHead("tchiki-tchiki");
         TuleapBranchSCMRevision tlpRevisionOrigin = new TuleapBranchSCMRevision(tlpScmHeadOrigin, "h4shu_or1g1n");
 
-        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget,4);
+        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget,4,4);
         TuleapPullRequestRevision tlpPrRevision = new TuleapPullRequestRevision(tlpPrScmHead, tlpRevisionTarget, tlpRevisionOrigin);
 
         String remote = "https://tuleap.example.com/repo.git";

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/SCMSourceCriteriaDefaultStub.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/stubs/SCMSourceCriteriaDefaultStub.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.stubs;
+
+import hudson.model.TaskListener;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public class SCMSourceCriteriaDefaultStub implements SCMSourceCriteria {
+    @Override
+    public boolean isHead(@NotNull Probe probe, @NotNull TaskListener listener) throws IOException {
+        return false;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMRequestTest.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.unit;
+
+import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
+import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapGitRepository;
+import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapProject;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSource;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceContext;
+import org.jenkinsci.plugins.tuleap_git_branch_source.TuleapSCMSourceRequest;
+import org.jenkinsci.plugins.tuleap_git_branch_source.stubs.SCMSourceCriteriaDefaultStub;
+import org.junit.Test;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static junit.framework.TestCase.*;
+
+public class TuleapSCMRequestTest {
+
+    @Test
+    public void testWeWantToRetrievePullRequestWhenWeTheWantForkTraitIsEnabled() {
+
+        TuleapSCMSource source = new TuleapSCMSource(new TuleapProject(), new TuleapGitRepository());
+
+        SCMSourceCriteriaDefaultStub criteriaDefaultStub = new SCMSourceCriteriaDefaultStub();
+        TuleapSCMSourceContext context = new TuleapSCMSourceContext(criteriaDefaultStub, SCMHeadObserver.none());
+        context.wantForkPullRequests(true);
+        context.wantOriginPullRequests(false);
+
+        TaskListener listener = new LogTaskListener(Logger.getLogger(getClass().getName()), Level.FINE);
+
+        TuleapSCMSourceRequest request = context.newRequest(source,listener);
+
+        assertTrue(request.isRetrievePullRequests());
+    }
+
+    @Test
+    public void testWeWantToRetrievePullRequestWhenWeTheWantOriginTraitIsEnabled() {
+
+        TuleapSCMSource source = new TuleapSCMSource(new TuleapProject(), new TuleapGitRepository());
+
+        SCMSourceCriteriaDefaultStub criteriaDefaultStub = new SCMSourceCriteriaDefaultStub();
+        TuleapSCMSourceContext context = new TuleapSCMSourceContext(criteriaDefaultStub, SCMHeadObserver.none());
+        context.wantForkPullRequests(false);
+        context.wantOriginPullRequests(true);
+
+        TaskListener listener = new LogTaskListener(Logger.getLogger(getClass().getName()), Level.FINE);
+
+        TuleapSCMSourceRequest request = context.newRequest(source,listener);
+
+        assertTrue(request.isRetrievePullRequests());
+    }
+
+    @Test
+    public void testWeDoNotWantToRetrievePullRequestWhenAnyPullRequestTraitIsEnabled() {
+
+        TuleapSCMSource source = new TuleapSCMSource(new TuleapProject(), new TuleapGitRepository());
+
+        SCMSourceCriteriaDefaultStub criteriaDefaultStub = new SCMSourceCriteriaDefaultStub();
+        TuleapSCMSourceContext context = new TuleapSCMSourceContext(criteriaDefaultStub, SCMHeadObserver.none());
+        context.wantForkPullRequests(false);
+        context.wantOriginPullRequests(false);
+
+        TaskListener listener = new LogTaskListener(Logger.getLogger(getClass().getName()), Level.FINE);
+
+        TuleapSCMSourceRequest request = context.newRequest(source,listener);
+
+        assertFalse(request.isRetrievePullRequests());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
@@ -85,7 +85,7 @@ public class TuleapSCMSourceTest {
 
         SCMHeadOrigin originHead = SCMHeadOrigin.DEFAULT;
         TuleapBranchSCMHead targetHead = new TuleapBranchSCMHead("my-c63-tlp-branch");
-        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead,10);
+        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead,10,10);
 
         TuleapBranchSCMRevision target = new TuleapBranchSCMRevision(head.getTarget(), "h4sH_t4rG3t");
         TuleapBranchSCMRevision origin = new TuleapBranchSCMRevision(new TuleapBranchSCMHead(head.getOriginName()), "h4sH_or1g1n");

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
@@ -85,7 +85,7 @@ public class TuleapSCMSourceTest {
 
         SCMHeadOrigin originHead = SCMHeadOrigin.DEFAULT;
         TuleapBranchSCMHead targetHead = new TuleapBranchSCMHead("my-c63-tlp-branch");
-        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead);
+        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead,10);
 
         TuleapBranchSCMRevision target = new TuleapBranchSCMRevision(head.getTarget(), "h4sH_t4rG3t");
         TuleapBranchSCMRevision origin = new TuleapBranchSCMRevision(new TuleapBranchSCMHead(head.getOriginName()), "h4sH_or1g1n");


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

How to test:
 - Enable the `Tuleap Pull Requests from origin autodiscovery` trait in
   the job configuration
 - Save the configuration and/or launch the scan
=> You should see the pull requests jobs created in the concerned
    repository
=> Others traits should work as before
