### PR TITLE
Add the 'Pull Requests' tab in the job repository

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -27,6 +27,8 @@ import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait;
 import jenkins.scm.api.*;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
+import jenkins.scm.impl.UncategorizedSCMHeadCategory;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.tuleap_git_branch_source.config.TuleapSCMFileSystem;
 import org.jenkinsci.plugins.tuleap_git_branch_source.helpers.TuleapApiRetriever;
@@ -508,6 +510,15 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
                 result.add(newItem);
             }
             return result;
+        }
+
+        @NonNull
+        @Override
+        protected SCMHeadCategory[] createCategories(){
+            return new SCMHeadCategory[]{
+                UncategorizedSCMHeadCategory.DEFAULT,
+                new ChangeRequestSCMHeadCategory(Messages._TuleapSCMSource_ChangeRequestCategory())
+            };
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapForkPullRequestDiscoveryTrait.java
@@ -8,6 +8,7 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
 import jenkins.scm.api.trait.*;
+import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.tuleap_git_branch_source.*;
@@ -37,7 +38,7 @@ public class TuleapForkPullRequestDiscoveryTrait extends SCMSourceTrait {
      */
     @Override
     public boolean includeCategory(@NonNull SCMHeadCategory category) {
-        return category.isUncategorized();
+        return category instanceof ChangeRequestSCMHeadCategory;
     }
 
     @Symbol("tuleapForkPullRequestDiscovery")

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapOriginPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/trait/TuleapOriginPullRequestDiscoveryTrait.java
@@ -5,6 +5,7 @@ import hudson.Extension;
 import jenkins.scm.api.*;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
 import jenkins.scm.api.trait.*;
+import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.tuleap_git_branch_source.Messages;
@@ -34,7 +35,7 @@ public class TuleapOriginPullRequestDiscoveryTrait extends SCMSourceTrait {
      */
     @Override
     public boolean includeCategory(@NonNull SCMHeadCategory category) {
-        return category.isUncategorized();
+        return category instanceof ChangeRequestSCMHeadCategory;
     }
 
     @Symbol("tuleapPullRequestDiscovery")

--- a/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/tuleap_git_branch_source/Messages.properties
@@ -14,3 +14,5 @@ TuleapForkPullRequestDiscoveryTrait.displayName=Tuleap Pull Requests from fork a
 TuleapCommitNotificationTrait.displayName=Notify build status to Tuleap
 
 WildcardSCMSourceFilterTrait.displayName=Filter repositories by name (wildcards)
+
+TuleapSCMSource.ChangeRequestCategory=Pull Requests


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

Now for each job repository, you should see the `Pull Requests` tab next
to the `Branches` tab

To see the new tab, you should at least rescan the Tuleap project.
