### PR TITLE
Add the Tuleap Git SCM  Browser

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapBrowser.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapBrowser.java
@@ -1,0 +1,66 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.browser.GitRepositoryBrowser;
+import hudson.scm.EditType;
+import hudson.scm.RepositoryBrowser;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class TuleapBrowser extends GitRepositoryBrowser {
+
+    @DataBoundConstructor
+    public TuleapBrowser(String repositoryUrl) {
+        super(repositoryUrl);
+    }
+
+    private String getRepositoryUrl() {
+        return super.getRepoUrl();
+    }
+
+    @Override
+    public URL getDiffLink(GitChangeSet.Path path) throws IOException {
+        if (path.getEditType() != EditType.EDIT || path.getSrc() == null || path.getDst() == null
+            || path.getChangeSet().getParentCommit() == null) {
+            return null;
+        }
+        return encodeURL(new URL(this.getRepositoryUrl() + "?a=commitdiff&h=" + path.getChangeSet().getId()));
+    }
+
+    @Override
+    public URL getFileLink(GitChangeSet.Path path) throws IOException, URISyntaxException {
+        if (path.getEditType().equals(EditType.DELETE)) {
+            return null;
+        }
+        URL fileUrl = new URL(this.getRepositoryUrl() + "?a=blob&hb=" + path.getChangeSet().getId() + "&f=" + path.getPath());
+        return encodeURL(fileUrl);
+    }
+
+    @Override
+    public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
+        return encodeURL(new URL(this.getRepositoryUrl() + "?a=commit&h=" + changeSet.getId()));
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
+
+        @NonNull
+        public String getDisplayName() {
+            return "Tuleap changeset";
+        }
+
+        @Override
+        public TuleapBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject)
+            throws FormException {
+            return req.bindJSON(TuleapBrowser.class, jsonObject);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilder.java
@@ -8,7 +8,7 @@ import jenkins.scm.api.SCMRevision;
 import org.jetbrains.annotations.NotNull;
 
 public class TuleapSCMBuilder extends GitSCMBuilder<TuleapSCMBuilder> {
-    public TuleapSCMBuilder(@NotNull SCMHead head, SCMRevision revision, @NotNull String remote, String credentialsId) {
+    public TuleapSCMBuilder(@NotNull SCMHead head, SCMRevision revision, @NotNull String remote, String credentialsId, String repositoryBaseUrl) {
         super(head, revision, remote, credentialsId);
         withoutRefSpecs();
         if (head instanceof TuleapPullRequestSCMHead) {
@@ -17,6 +17,7 @@ public class TuleapSCMBuilder extends GitSCMBuilder<TuleapSCMBuilder> {
         } else {
             withRefSpec("+refs/heads/" + head.getName() + ":refs/remotes/@{remote}/" + head.getName());
         }
+        withBrowser(new TuleapBrowser(repositoryBaseUrl));
     }
 
     @NonNull

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -362,7 +362,8 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
     @NotNull
     @Override
     public SCM build(@NonNull SCMHead scmHead, @CheckForNull SCMRevision scmRevision) {
-        return new TuleapSCMBuilder(scmHead, scmRevision, remoteUrl, credentialsId).withTraits(traits).build();
+        String repositoryUri = this.getGitBaseUri() + this.project.getShortname() + "/" +this.repository.getName();
+        return new TuleapSCMBuilder(scmHead, scmRevision, remoteUrl, credentialsId, repositoryUri).withTraits(traits).build();
     }
 
     public List<SCMSourceTrait> getTraits() {

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapBrowserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapBrowserTest.java
@@ -1,0 +1,130 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import hudson.plugins.git.GitChangeSet;
+import hudson.scm.EditType;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TuleapBrowserTest {
+
+    @Test
+    public void testItReturnsNoDiffLinkIfTheFileIsNotEditedInTheLastCommit() throws IOException {
+        String parentLine = "parent h4sh_s0m3";
+        List<String> lines = Collections.singletonList(parentLine);
+        GitChangeSet changeSet = new GitChangeSet(lines, false);
+
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.ADD);
+        when(path.getSrc()).thenReturn("source/file");
+        when(path.getDst()).thenReturn("dest/file");
+        when(path.getChangeSet()).thenReturn(changeSet);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertNull(browser.getDiffLink(path));
+    }
+
+    @Test
+    public void testItReturnsNoDiffLinkIfTheFileDoesNotHaveSourcePath() throws IOException {
+        String parentLine = "parent h4sh_s0m3";
+        List<String> lines = Collections.singletonList(parentLine);
+        GitChangeSet changeSet = new GitChangeSet(lines, false);
+
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.EDIT);
+        when(path.getSrc()).thenReturn(null);
+        when(path.getDst()).thenReturn("dest/file");
+        when(path.getChangeSet()).thenReturn(changeSet);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertNull(browser.getDiffLink(path));
+    }
+
+    @Test
+    public void testItReturnsNoDiffLinkIfTheFileDoesNotHaveDestinationPath() throws IOException {
+        String parentLine = "parent h4sh_s0m3";
+        List<String> lines = Collections.singletonList(parentLine);
+        GitChangeSet changeSet = new GitChangeSet(lines, false);
+
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.EDIT);
+        when(path.getSrc()).thenReturn("source/file");
+        when(path.getDst()).thenReturn(null);
+        when(path.getChangeSet()).thenReturn(changeSet);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertNull(browser.getDiffLink(path));
+    }
+
+    @Test
+    public void testItReturnsNoDiffLinkIfTheFileDoesNotHaveParentCommit() throws IOException {
+        String treeLine = "tree h4sh_s0m3";
+        List<String> lines = Collections.singletonList(treeLine);
+        GitChangeSet changeSet = new GitChangeSet(lines, false);
+
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.EDIT);
+        when(path.getSrc()).thenReturn("source/file");
+        when(path.getDst()).thenReturn("dest/file");
+        when(path.getChangeSet()).thenReturn(changeSet);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertNull(browser.getDiffLink(path));
+    }
+
+    @Test
+    public void testItReturnsTheDiffLink() throws IOException {
+        String treeLine = "parent h4sh_s0m3";
+        List<String> lines = Collections.singletonList(treeLine);
+        GitChangeSet changeSet = new GitChangeSet(lines, false);
+
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.EDIT);
+        when(path.getSrc()).thenReturn("source/file");
+        when(path.getDst()).thenReturn("dest/file");
+        when(path.getChangeSet()).thenReturn(changeSet);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertEquals(new URL("https://tuleap.example.com/plugins/git/naha/repo01?a=commitdiff&h=null"), browser.getDiffLink(path));
+    }
+
+    @Test
+    public void testItDoesNotReturnTheFileLinkContentIfTheFileIsInDeleteMode() throws IOException, URISyntaxException {
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.DELETE);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertNull(browser.getFileLink(path));
+    }
+
+    @Test
+    public void testItReturnsTheFileLinkContentIfTheFileIsNotInDeleteMode() throws IOException, URISyntaxException {
+        String commitIdLine = "commit h4sh_s0m3";
+        List<String> lines = Collections.singletonList(commitIdLine);
+        GitChangeSet changeSet = new GitChangeSet(lines, false);
+
+        GitChangeSet.Path path = mock(GitChangeSet.Path.class);
+        when(path.getEditType()).thenReturn(EditType.EDIT).thenReturn(EditType.ADD);
+        when(path.getChangeSet()).thenReturn(changeSet);
+
+        TuleapBrowser browser = new TuleapBrowser("https://tuleap.example.com/plugins/git/naha/repo01");
+
+        assertEquals(new URL("https://tuleap.example.com/plugins/git/naha/repo01?a=blob&hb=h4sh_s0m3&f=null"), browser.getFileLink(path));
+        assertEquals(new URL("https://tuleap.example.com/plugins/git/naha/repo01?a=blob&hb=h4sh_s0m3&f=null"), browser.getFileLink(path));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
@@ -19,7 +19,7 @@ public class TuleapSCMBuilderTest {
         String remote = "https://tuleap.example.com/repo.git";
         String credentialsId = "1581";
 
-        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpScmHead, tlpRevision, remote, credentialsId);
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpScmHead, tlpRevision, remote, credentialsId,"https://tuleap.example.com/plugins/git/somerepo");
         assertEquals(1, tuleapSCMBuilder.refSpecs().size());
         assertEquals("+refs/heads/jcomprendspas-branch:refs/remotes/@{remote}/jcomprendspas-branch", tuleapSCMBuilder.refSpecs().get(0));
         assertEquals("https://tuleap.example.com/repo.git", tuleapSCMBuilder.remote());
@@ -39,7 +39,7 @@ public class TuleapSCMBuilderTest {
         String remote = "https://tuleap.example.com/repo.git";
         String credentialsId = "1581";
 
-        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId);
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId, "https://tuleap.example.com/plugins/git/somerepo");
         assertEquals(1, tuleapSCMBuilder.refSpecs().size());
         assertEquals("+refs/tlpr/3/head:refs/remotes/@{remote}/TLP-PR-3", tuleapSCMBuilder.refSpecs().get(0));
         assertEquals("https://tuleap.example.com/repo.git", tuleapSCMBuilder.remote());
@@ -54,7 +54,7 @@ public class TuleapSCMBuilderTest {
         String remote = "https://tuleap.example.com/repo.git";
         String credentialsId = "1581";
 
-        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId);
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId, "https://tuleap.example.com/plugins/git/somerepo");
 
         tuleapSCMBuilder.build();
         verify(tlpPrRevision, atLeastOnce()).getOrigin();
@@ -72,7 +72,7 @@ public class TuleapSCMBuilderTest {
         String remote = "https://tuleap.example.com/repo.git";
         String credentialsId = "1581";
 
-        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpScmHead, tlpRevision, remote, credentialsId);
+        TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpScmHead, tlpRevision, remote, credentialsId, "https://tuleap.example.com/plugins/git/somerepo");
 
         tuleapSCMBuilder.build();
         assertEquals(tlpRevision, tuleapSCMBuilder.revision());


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

How to test:

 - In your Tuleap repository push new content which contains a new file,
   a deleted file and an edited file.
 - In Jenkins, launch a new build of the modified branch job
 - When the build is finish go into the job and click on the `details`
   link under the `Changes` section.
=> You should see the modified/removed and added file and commit id
=> Click on the different links and you should be redirected to the
concerned Tuleap file/commit/diff
=> When a file is removed, there is no link
