### PR TITLE
Remove the REST API call to get the Jenkinsfile

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -144,31 +144,20 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
                 int count = 0;
                 for (TuleapBranches branch : branches.collect(Collectors.toList())) {
                     count++;
-                    request.listener().getLogger().println("Get the Jenkinsfile from Tuleap.");
-                    Optional<TuleapFileContent> file = TuleapClientCommandConfigurer.<Optional<TuleapFileContent>>newInstance(getApiBaseUri())
-                        .withCredentials(credentials)
-                        .withCommand(new TuleapClientRawCmd.GetJenkinsFile(repository.getId(), "Jenkinsfile", branch.getName()))
-                        .configure()
-                        .call();
-                    if (file.get().getName() != null) {
-                        request.listener().getLogger().format("Search at '%s'", branch.getName());
-                        TuleapBranchSCMHead tuleapBranchSCMHead = new TuleapBranchSCMHead(branch.getName());
-                        if (request.process(tuleapBranchSCMHead, (SCMSourceRequest.RevisionLambda<TuleapBranchSCMHead, TuleapBranchSCMRevision>) head ->
-                                new TuleapBranchSCMRevision(head, branch.getCommit().getId()),
-                            new SCMSourceRequest.ProbeLambda<TuleapBranchSCMHead, TuleapBranchSCMRevision>() {
-                                @NotNull
-                                @Override
-                                public SCMSourceCriteria.Probe create(@NotNull TuleapBranchSCMHead head, @Nullable TuleapBranchSCMRevision revisionInfo) throws IOException, InterruptedException {
-                                    return createProbe(head, revisionInfo);
-                                }
-                            }, new OFWitness(listener))) {
-                            request.listener().getLogger()
-                                .format("%n  %d branches were processed (query completed)%n", count).println();
-                        }
-                    } else {
-                        request.listener().getLogger().format("There is no Jenkinsfile at the branch: %s %n", branch.getName());
+                    request.listener().getLogger().format("Search at '%s'", branch.getName());
+                    TuleapBranchSCMHead tuleapBranchSCMHead = new TuleapBranchSCMHead(branch.getName());
+                    if (request.process(tuleapBranchSCMHead, (SCMSourceRequest.RevisionLambda<TuleapBranchSCMHead, TuleapBranchSCMRevision>) head ->
+                            new TuleapBranchSCMRevision(head, branch.getCommit().getId()),
+                        new SCMSourceRequest.ProbeLambda<TuleapBranchSCMHead, TuleapBranchSCMRevision>() {
+                            @NotNull
+                            @Override
+                            public SCMSourceCriteria.Probe create(@NotNull TuleapBranchSCMHead head, @Nullable TuleapBranchSCMRevision revisionInfo) throws IOException, InterruptedException {
+                                return createProbe(head, revisionInfo);
+                            }
+                        }, new OFWitness(listener))) {
+                        request.listener().getLogger()
+                            .format("%n  %d branches were processed (query completed)%n", count).println();
                     }
-
                 }
 
             }


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

Since the implementation of a dedicated FileSystem, there is no need to
check if the Jenkinsfile exist or not anymore.
This is now delegated to the TuleapFileSystem class

