### PR TITLE
fix: Retrieve the right Jenkinsfile when both PR trait are enabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/config/TuleapSCMFileSystem.java
@@ -86,15 +86,12 @@ public class TuleapSCMFileSystem extends SCMFileSystem {
                 repositoryId = Integer.toString(tuleapSCMSource.getTuleapGitRepository().getId());
             } else if (head instanceof TuleapPullRequestSCMHead) {
                 TuleapPullRequestSCMHead tlpHead = ((TuleapPullRequestSCMHead) head);
-                List<SCMSourceTrait> traits = source.getTraits();
-                assert traits != null;
-                boolean hasForkTrait = traits.stream().anyMatch(scmSourceTrait -> scmSourceTrait instanceof TuleapForkPullRequestDiscoveryTrait);
-                if (hasForkTrait) {
-                    ref = tlpHead.getTarget().getName();
-                    repositoryId = Integer.toString(tlpHead.getTargetRepositoryId());
-                } else {
+                if (rev instanceof TuleapPullRequestRevision) {
                     ref = ((TuleapPullRequestSCMHead) head).getOriginName();
                     repositoryId = Integer.toString(((TuleapPullRequestSCMHead) head).getOriginRepositoryId());
+                } else {
+                    ref = tlpHead.getTarget().getName();
+                    repositoryId = Integer.toString(tlpHead.getTargetRepositoryId());
                 }
             } else {
                 return null;


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

When the both Pull Request traits are enabled the wrong Jenkinsfile
content was read by Jenkins. The Jenkinsfile from the target branch is
read instead of the origin branch even if the origin branch is
considered as trusted!

How to test:
 - Have the both Tuleap Pull Request traits.
 - Launch the job
=> For each Tuleap PR found, make sure that the right Jenkinsfile is
read by Jenkins