### PR TITLE
Fix Wrong PR head reference is being pulled on build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>tuleap-api</artifactId>
-      <version>2.4.1</version>
+      <version>2.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestSCMHead.java
@@ -15,14 +15,16 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
     private final TuleapBranchSCMHead target;
     private final int originRepositoryId;
     private final Integer targetRepositoryId;
+    private final String headReference;
 
-    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target, Integer originRepositoryId, Integer targetRepositoryId) {
+    public TuleapPullRequestSCMHead(GitPullRequest pullRequest, SCMHeadOrigin origin, TuleapBranchSCMHead target, Integer originRepositoryId, Integer targetRepositoryId, String headReference) {
         super("TLP-PR-" + pullRequest.getId());
         this.pullRequest = pullRequest;
         this.origin = origin;
         this.target = target;
         this.originRepositoryId = originRepositoryId;
         this.targetRepositoryId = targetRepositoryId;
+        this.headReference = headReference;
     }
 
     @NotNull
@@ -61,5 +63,9 @@ public class TuleapPullRequestSCMHead extends SCMHead implements ChangeRequestSC
 
     public Integer getTargetRepositoryId() {
         return this.targetRepositoryId;
+    }
+
+    public String getHeadReference() {
+        return this.headReference;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilder.java
@@ -16,7 +16,7 @@ public class TuleapSCMBuilder extends GitSCMBuilder<TuleapSCMBuilder> {
         withoutRefSpecs();
         if (head instanceof TuleapPullRequestSCMHead) {
             TuleapPullRequestSCMHead tuleapPullRequestSCMHead = (TuleapPullRequestSCMHead) head;
-            withRefSpec("+refs/tlpr/" + tuleapPullRequestSCMHead.getId() + "/head:refs/remotes/@{remote}/" + tuleapPullRequestSCMHead.getName());
+            withRefSpec("+" + tuleapPullRequestSCMHead.getHeadReference() + ":refs/remotes/@{remote}/" + tuleapPullRequestSCMHead.getName());
         } else {
             withRefSpec("+refs/heads/" + head.getName() + ":refs/remotes/@{remote}/" + head.getName());
         }

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPullRequestRevisionTest.java
@@ -24,7 +24,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 102);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 102, "refs/tlpr/4");
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -39,7 +39,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 101);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 101, "refs/tlpr/4");
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -54,7 +54,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead originBranch = new TuleapBranchSCMHead("origino-branchu");
         TuleapBranchSCMRevision originBranchRevision = new TuleapBranchSCMRevision(originBranch, "0r1g4n_h4sh");
 
-        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 102);
+        TuleapPullRequestSCMHead pullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, targetBranch, 101, 102, "refs/tlpr/4");
 
         TuleapPullRequestRevision tuleapPullRequestRevision = new TuleapPullRequestRevision(pullRequestSCMHead, targetBranchRevision, originBranchRevision);
 
@@ -64,7 +64,7 @@ public class TuleapPullRequestRevisionTest {
         TuleapBranchSCMHead otherOriginBranch = new TuleapBranchSCMHead("origino-0th3r-branchu");
         TuleapBranchSCMRevision otherOriginBranchRevision = new TuleapBranchSCMRevision(otherOriginBranch, "0r1g4n_h4sh_-0th3r");
 
-        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch, 101, 102);
+        TuleapPullRequestSCMHead otherPullRequestSCMHead = new TuleapPullRequestSCMHead(this.getGitPullRequest(), SCMHeadOrigin.DEFAULT, otherTargetBranch, 101, 102, "refs/tlpr/4");
 
         TuleapPullRequestRevision otherPullRequestRevision = new TuleapPullRequestRevision(otherPullRequestSCMHead, otherTargetBranchRevision,otherOriginBranchRevision);
         assertFalse(tuleapPullRequestRevision.equivalent(otherPullRequestRevision));

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMBuilderTest.java
@@ -33,7 +33,7 @@ public class TuleapSCMBuilderTest {
         TuleapBranchSCMHead tlpScmHeadOrigin = new TuleapBranchSCMHead("tchiki-tchiki");
         TuleapBranchSCMRevision tlpRevisionOrigin = new TuleapBranchSCMRevision(tlpScmHeadOrigin, "h4shu_or1g1n");
 
-        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget,4,4);
+        TuleapPullRequestSCMHead tlpPrScmHead = new TuleapPullRequestSCMHead(this.getPullRequest(), SCMHeadOrigin.DEFAULT, tlpScmHeadTarget,4,4, "refs/tlpr/4");
         TuleapPullRequestRevision tlpPrRevision = new TuleapPullRequestRevision(tlpPrScmHead, tlpRevisionTarget, tlpRevisionOrigin);
 
         String remote = "https://tuleap.example.com/repo.git";
@@ -41,7 +41,7 @@ public class TuleapSCMBuilderTest {
 
         TuleapSCMBuilder tuleapSCMBuilder = new TuleapSCMBuilder(tlpPrScmHead, tlpPrRevision, remote, credentialsId, "https://tuleap.example.com/plugins/git/somerepo");
         assertEquals(1, tuleapSCMBuilder.refSpecs().size());
-        assertEquals("+refs/tlpr/3/head:refs/remotes/@{remote}/TLP-PR-3", tuleapSCMBuilder.refSpecs().get(0));
+        assertEquals("+refs/tlpr/4:refs/remotes/@{remote}/TLP-PR-3", tuleapSCMBuilder.refSpecs().get(0));
         assertEquals("https://tuleap.example.com/repo.git", tuleapSCMBuilder.remote());
     }
 

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/unit/TuleapSCMSourceTest.java
@@ -85,7 +85,7 @@ public class TuleapSCMSourceTest {
 
         SCMHeadOrigin originHead = SCMHeadOrigin.DEFAULT;
         TuleapBranchSCMHead targetHead = new TuleapBranchSCMHead("my-c63-tlp-branch");
-        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead,10,10);
+        TuleapPullRequestSCMHead head = new TuleapPullRequestSCMHead(pullRequest, originHead, targetHead,10,10, "refs/tlpr/4");
 
         TuleapBranchSCMRevision target = new TuleapBranchSCMRevision(head.getTarget(), "h4sH_t4rG3t");
         TuleapBranchSCMRevision origin = new TuleapBranchSCMRevision(new TuleapBranchSCMHead(head.getOriginName()), "h4sH_or1g1n");


### PR DESCRIPTION
This change fixes [Tuleap #23048](https://tuleap.net/plugins/tracker/?aid=23048)

How to test:

* Have at least two repositories with one pull request in each
* Create a Tuleap Job that scans those two repositories
* Check that all pull requests are build correctly instead of one
  failing because Jenkins can't fetch the reference.