### PR TITLE
Fix: Error when upgrading old job config with tuleap-git-branch-source 3.2.0

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigator.java
@@ -42,6 +42,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.io.ObjectStreamException;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ public class TuleapSCMNavigator extends SCMNavigator {
     private static final String TULEAP_FORK_PARTIAL_PATH = "/u/";
 
     private String tuleapProjectId;
+    private String projectId;
     private List<SCMTrait<? extends SCMTrait<?>>> traits;
     private String credentialsId;
     private String apiUri, gitBaseUri;
@@ -64,6 +66,15 @@ public class TuleapSCMNavigator extends SCMNavigator {
     @DataBoundConstructor
     public TuleapSCMNavigator(String tuleapProjectId) {
         this.tuleapProjectId = tuleapProjectId;
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+        if (! (this.projectId == null)) {
+            this.tuleapProjectId = this.projectId;
+            this.projectId = null;
+        }
+
+        return this;
     }
 
     @NonNull

--- a/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest.java
@@ -1,0 +1,33 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source;
+
+import jenkins.branch.OrganizationFolder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import static org.junit.Assert.assertEquals;
+
+public class TuleapSCMNavigatorDeserializationTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    @LocalData
+    public void deserializationOfNewTuleapProjectIdAttributeWorks() {
+        OrganizationFolder folder = (OrganizationFolder) jenkins.getInstance().getItemByFullName("step");
+        TuleapSCMNavigator navigator = folder.getNavigators().get(TuleapSCMNavigator.class);
+
+        assertEquals(navigator.getTuleapProjectId(), "101");
+    }
+
+    @Test
+    @LocalData
+    public void deserializationOfOldProjectIdAttributeWorks() {
+        OrganizationFolder folder = (OrganizationFolder) jenkins.getInstance().getItemByFullName("step");
+        TuleapSCMNavigator navigator = folder.getNavigators().get(TuleapSCMNavigator.class);
+
+        assertEquals(navigator.getTuleapProjectId(), "101");
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfNewTuleapProjectIdAttributeWorks/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfNewTuleapProjectIdAttributeWorks/config.xml
@@ -1,0 +1,38 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>2.249.3</version>
+  <installStateName>DEVELOPMENT</installStateName>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>all</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>all</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+  </crumbIssuer>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfNewTuleapProjectIdAttributeWorks/jobs/step/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfNewTuleapProjectIdAttributeWorks/jobs/step/config.xml
@@ -1,0 +1,94 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.branch.OrganizationFolder plugin="branch-api@2.6.2">
+  <actions/>
+  <description></description>
+  <properties>
+    <jenkins.branch.OrganizationChildHealthMetricsProperty>
+      <templates>
+        <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder@6.16">
+          <nonRecursive>false</nonRecursive>
+        </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      </templates>
+    </jenkins.branch.OrganizationChildHealthMetricsProperty>
+    <jenkins.branch.OrganizationChildOrphanedItemsProperty>
+      <strategy class="jenkins.branch.OrganizationChildOrphanedItemsProperty$Inherit"/>
+    </jenkins.branch.OrganizationChildOrphanedItemsProperty>
+    <jenkins.branch.OrganizationChildTriggersProperty>
+      <templates>
+        <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.16">
+          <spec>H H/4 * * *</spec>
+          <interval>86400000</interval>
+        </com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
+      </templates>
+    </jenkins.branch.OrganizationChildTriggersProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty plugin="cloudbees-folder@6.16">
+      <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
+        <entry>
+          <com.cloudbees.plugins.credentials.domains.Domain plugin="credentials@2.6.1">
+            <specifications/>
+          </com.cloudbees.plugins.credentials.domains.Domain>
+          <java.util.concurrent.CopyOnWriteArrayList>
+            <io.jenkins.plugins.tuleap__credentials.TuleapAccessTokenImpl plugin="tuleap-api@2.4.2">
+              <id>627eca5f-a6b1-4383-8e08-4674b52981ea</id>
+              <description></description>
+              <token>{AQAAABAAAABQWF+9ckmrFkPty2t6PI4EhGW/udzBu2KZv6Uzjd8B0hO79lIQfm2S2fVEAchMiHpE+Tj2ifLNKYDUb4SffOvRzolVymza5SbCDN2436a/c6DPzhjrsHsCSbqVV8vrh7Qm}</token>
+            </io.jenkins.plugins.tuleap__credentials.TuleapAccessTokenImpl>
+          </java.util.concurrent.CopyOnWriteArrayList>
+        </entry>
+      </domainCredentialsMap>
+    </com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+    <jenkins.branch.NoTriggerOrganizationFolderProperty>
+      <branches>.*</branches>
+    </jenkins.branch.NoTriggerOrganizationFolderProperty>
+  </properties>
+  <folderViews class="jenkins.branch.OrganizationFolderViewHolder">
+    <owner reference="../.."/>
+  </folderViews>
+  <healthMetrics/>
+  <icon class="jenkins.branch.MetadataActionFolderIcon">
+    <owner class="jenkins.branch.OrganizationFolder" reference="../.."/>
+  </icon>
+  <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@6.16">
+    <pruneDeadBranches>true</pruneDeadBranches>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>-1</numToKeep>
+  </orphanedItemStrategy>
+  <triggers>
+    <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.16">
+      <spec>H H/4 * * *</spec>
+      <interval>86400000</interval>
+    </com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
+  </triggers>
+  <disabled>false</disabled>
+  <navigators>
+    <org.jenkinsci.plugins.tuleap__git__branch__source.TuleapSCMNavigator plugin="tuleap-git-branch-source@3.2.1-SNAPSHOT">
+      <tuleapProjectId>101</tuleapProjectId>
+      <traits>
+        <jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait plugin="scm-api@2.6.5">
+          <includes>*</includes>
+          <excludes></excludes>
+        </jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait>
+        <org.jenkinsci.plugins.tuleap__git__branch__source.trait.TuleapBranchDiscoveryTrait/>
+        <org.jenkinsci.plugins.tuleap__git__branch__source.trait.TuleapOriginPullRequestDiscoveryTrait/>
+        <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait plugin="git@4.6.0">
+          <templates>
+            <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+              <value></value>
+            </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+          </templates>
+        </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+      </traits>
+      <credentialsId>627eca5f-a6b1-4383-8e08-4674b52981ea</credentialsId>
+      <repositories/>
+    </org.jenkinsci.plugins.tuleap__git__branch__source.TuleapSCMNavigator>
+  </navigators>
+  <projectFactories>
+    <org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory plugin="workflow-multibranch@2.24">
+      <scriptPath>Jenkinsfile</scriptPath>
+    </org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory>
+  </projectFactories>
+  <buildStrategies/>
+  <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
+    <properties class="empty-list"/>
+  </strategy>
+</jenkins.branch.OrganizationFolder>

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfOldProjectIdAttributeWorks/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfOldProjectIdAttributeWorks/config.xml
@@ -1,0 +1,38 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>2.249.3</version>
+  <installStateName>DEVELOPMENT</installStateName>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>all</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>all</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+  </crumbIssuer>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfOldProjectIdAttributeWorks/jobs/step/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMNavigatorDeserializationTest/deserializationOfOldProjectIdAttributeWorks/jobs/step/config.xml
@@ -1,0 +1,94 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.branch.OrganizationFolder plugin="branch-api@2.6.2">
+  <actions/>
+  <description></description>
+  <properties>
+    <jenkins.branch.OrganizationChildHealthMetricsProperty>
+      <templates>
+        <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder@6.16">
+          <nonRecursive>false</nonRecursive>
+        </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      </templates>
+    </jenkins.branch.OrganizationChildHealthMetricsProperty>
+    <jenkins.branch.OrganizationChildOrphanedItemsProperty>
+      <strategy class="jenkins.branch.OrganizationChildOrphanedItemsProperty$Inherit"/>
+    </jenkins.branch.OrganizationChildOrphanedItemsProperty>
+    <jenkins.branch.OrganizationChildTriggersProperty>
+      <templates>
+        <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.16">
+          <spec>H H/4 * * *</spec>
+          <interval>86400000</interval>
+        </com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
+      </templates>
+    </jenkins.branch.OrganizationChildTriggersProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty plugin="cloudbees-folder@6.16">
+      <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
+        <entry>
+          <com.cloudbees.plugins.credentials.domains.Domain plugin="credentials@2.6.1">
+            <specifications/>
+          </com.cloudbees.plugins.credentials.domains.Domain>
+          <java.util.concurrent.CopyOnWriteArrayList>
+            <io.jenkins.plugins.tuleap__credentials.TuleapAccessTokenImpl plugin="tuleap-api@2.4.2">
+              <id>627eca5f-a6b1-4383-8e08-4674b52981ea</id>
+              <description></description>
+              <token>{AQAAABAAAABQWF+9ckmrFkPty2t6PI4EhGW/udzBu2KZv6Uzjd8B0hO79lIQfm2S2fVEAchMiHpE+Tj2ifLNKYDUb4SffOvRzolVymza5SbCDN2436a/c6DPzhjrsHsCSbqVV8vrh7Qm}</token>
+            </io.jenkins.plugins.tuleap__credentials.TuleapAccessTokenImpl>
+          </java.util.concurrent.CopyOnWriteArrayList>
+        </entry>
+      </domainCredentialsMap>
+    </com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+    <jenkins.branch.NoTriggerOrganizationFolderProperty>
+      <branches>.*</branches>
+    </jenkins.branch.NoTriggerOrganizationFolderProperty>
+  </properties>
+  <folderViews class="jenkins.branch.OrganizationFolderViewHolder">
+    <owner reference="../.."/>
+  </folderViews>
+  <healthMetrics/>
+  <icon class="jenkins.branch.MetadataActionFolderIcon">
+    <owner class="jenkins.branch.OrganizationFolder" reference="../.."/>
+  </icon>
+  <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@6.16">
+    <pruneDeadBranches>true</pruneDeadBranches>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>-1</numToKeep>
+  </orphanedItemStrategy>
+  <triggers>
+    <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.16">
+      <spec>H H/4 * * *</spec>
+      <interval>86400000</interval>
+    </com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
+  </triggers>
+  <disabled>false</disabled>
+  <navigators>
+    <org.jenkinsci.plugins.tuleap__git__branch__source.TuleapSCMNavigator plugin="tuleap-git-branch-source@3.2.1-SNAPSHOT">
+      <projectId>101</projectId>
+      <traits>
+        <jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait plugin="scm-api@2.6.5">
+          <includes>*</includes>
+          <excludes></excludes>
+        </jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait>
+        <org.jenkinsci.plugins.tuleap__git__branch__source.trait.TuleapBranchDiscoveryTrait/>
+        <org.jenkinsci.plugins.tuleap__git__branch__source.trait.TuleapOriginPullRequestDiscoveryTrait/>
+        <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait plugin="git@4.6.0">
+          <templates>
+            <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+              <value></value>
+            </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+          </templates>
+        </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+      </traits>
+      <credentialsId>627eca5f-a6b1-4383-8e08-4674b52981ea</credentialsId>
+      <repositories/>
+    </org.jenkinsci.plugins.tuleap__git__branch__source.TuleapSCMNavigator>
+  </navigators>
+  <projectFactories>
+    <org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory plugin="workflow-multibranch@2.24">
+      <scriptPath>Jenkinsfile</scriptPath>
+    </org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory>
+  </projectFactories>
+  <buildStrategies/>
+  <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
+    <properties class="empty-list"/>
+  </strategy>
+</jenkins.branch.OrganizationFolder>


### PR DESCRIPTION
This change fixes [request #23423](https://tuleap.net/plugins/tracker/?aid=23423)

In order to test:

* Have an old Tuleap job config or change in your job xml `tuleapProjectId` by
  `projectId`.
* Start back your Jenkins instance and run the scan of the tuleap
  repositorise
* You shouldn't have errors in the scan log