### PR TITLE
fix: Tuleap job should send the right SHA-1 to the Tuleap git repository

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapSCMSource.java
@@ -16,7 +16,6 @@ import io.jenkins.plugins.tuleap_api.client.*;
 import io.jenkins.plugins.tuleap_api.deprecated_client.TuleapClientCommandConfigurer;
 import io.jenkins.plugins.tuleap_api.deprecated_client.TuleapClientRawCmd;
 import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapBranches;
-import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapFileContent;
 import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapGitRepository;
 import io.jenkins.plugins.tuleap_api.deprecated_client.api.TuleapProject;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
@@ -311,7 +310,7 @@ public class TuleapSCMSource extends AbstractGitSCMSource {
                 listener.getLogger().format("Cannot find the branch %s in repo : %s", head.getName(), repositoryPath);
             }
             if (revision.isPresent()) {
-                return new SCMRevisionImpl(head, revision.get());
+                return new TuleapBranchSCMRevision(head, revision.get());
             }
         } else if (head instanceof TuleapPullRequestSCMHead) {
             TuleapPullRequestSCMHead tlpSCMHead = (TuleapPullRequestSCMHead) head;

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/InvalidRetrievedRevisionType.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/InvalidRetrievedRevisionType.java
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.tuleap_git_branch_source.notify;
+
+public class InvalidRetrievedRevisionType extends RuntimeException {
+    public InvalidRetrievedRevisionType() {
+        super("Given revision is not from a Tuleap revision");
+    }
+}


### PR DESCRIPTION
request #21765 Tuleap PR autonotification notify the git repository with a inexistent SHA-1

For each checkouted git repository by Jenkins a new Git Build Data is
created. The current implementation does not take in account that
case, the consequence is when there are more than one Git Build Data,
we may notify the Tuleap git repository with an invalid SHA-1.

To test, you can use a shared library and add it in your Jenkinsfile
For example, you can use: https://github.com/monodot/pipeline-library-demo as shared library
=> The right Tuleap repository with the right SHA-1 should be notified

