### PR TITLE
fix: Send the pending status to Tuleap when the job start

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPipelineWatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/TuleapPipelineWatcher.java
@@ -4,21 +4,16 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.FilePath;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import hudson.model.listeners.SCMListener;
-import hudson.scm.SCM;
-import hudson.scm.SCMRevisionState;
 import io.jenkins.plugins.tuleap_api.client.GitApi;
 import io.jenkins.plugins.tuleap_api.client.TuleapApiGuiceModule;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
 import org.jenkinsci.plugins.tuleap_git_branch_source.notify.TuleapPipelineStatusHandler;
 import org.jenkinsci.plugins.tuleap_git_branch_source.notify.TuleapPipelineStatusNotifier;
 
-import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,23 +31,14 @@ public class TuleapPipelineWatcher {
     }
 
     @Extension
-    public static class TuleapJobCheckOutListener extends SCMListener {
+    public static class TuleapJobCompletedListener extends RunListener<Run<?, ?>> {
+
         @Override
-        public void onCheckout(
-            Run<?, ?> build,
-            SCM scm,
-            FilePath workspace,
-            TaskListener listener,
-            File changelogFile,
-            SCMRevisionState pollingBaseline
-        ) {
-            LOGGER.log(Level.INFO, String.format("Tuleap build: Checkout > %s", build.getFullDisplayName()));
+        public void onStarted(Run<?, ?> build, @NonNull TaskListener listener) {
+            LOGGER.log(Level.INFO, String.format("Tuleap build: Start > %s", build.getFullDisplayName()));
             getHandler().handleCommitNotification(build, listener.getLogger(), TuleapBuildStatus.pending);
         }
-    }
 
-    @Extension
-    public static class TuleapJobCompletedListener extends RunListener<Run<?, ?>> {
         @Override
         public void onCompleted(Run<?, ?> build, @NonNull TaskListener listener) {
             LOGGER.log(Level.INFO, String.format("Tuleap build: Complete > %s", build.getFullDisplayName()));

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifier.java
@@ -34,7 +34,7 @@ public class TuleapPipelineStatusNotifier {
 
         final int repository_id = source.getTuleapGitRepository().getId();
         logger.printf(
-            "Notifying Tuleap about build status: %s",
+            "Notifying Tuleap about build status: %s \n",
             status.toString()
         );
 

--- a/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/tuleap_git_branch_source/notify/TuleapPipelineStatusNotifier.java
@@ -34,7 +34,7 @@ public class TuleapPipelineStatusNotifier {
 
         final int repository_id = source.getTuleapGitRepository().getId();
         logger.printf(
-            "Notifying Tuleap about build status: %s \n",
+            "Notifying Tuleap about build status: %s %n",
             status.toString()
         );
 


### PR DESCRIPTION
[request #27168](https://tuleap.net/plugins/tracker/?aid=27168) Tuleap should not rely on the onCheckout event

The first notification must be done when the build start and not whenever a
repository is checkouted during the build.

Bonus: I also take the opportunity to fix a forgotten line return.